### PR TITLE
Fix secret selector of google_secret_manager_secret_version

### DIFF
--- a/apis/secretmanager/v1beta1/zz_generated.resolvers.go
+++ b/apis/secretmanager/v1beta1/zz_generated.resolvers.go
@@ -60,7 +60,7 @@ func (mg *SecretVersion) ResolveReferences(ctx context.Context, c client.Reader)
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Secret),
-		Extract:      reference.ExternalName(),
+		Extract:      common.ExtractResourceID(),
 		Reference:    mg.Spec.ForProvider.SecretRef,
 		Selector:     mg.Spec.ForProvider.SecretSelector,
 		To: reference.To{

--- a/apis/secretmanager/v1beta1/zz_secretversion_types.go
+++ b/apis/secretmanager/v1beta1/zz_secretversion_types.go
@@ -49,6 +49,7 @@ type SecretVersionParameters struct {
 
 	// Secret Manager secret resource
 	// +crossplane:generate:reference:type=Secret
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Secret *string `json:"secret,omitempty" tf:"secret,omitempty"`
 

--- a/config/secretmanager/config.go
+++ b/config/secretmanager/config.go
@@ -21,7 +21,8 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_secret_manager_secret_version", func(r *config.Resource) {
 		r.References["secret"] = config.Reference{
-			Type: "Secret",
+			Type:      "Secret",
+			Extractor: common.ExtractResourceIDFuncPath,
 		}
 	})
 }


### PR DESCRIPTION
Fixes the selector extractor.

Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #45 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually
```
NAME                                              READY   SYNCED   EXTERNAL-NAME
                   AGE
secretversion.secretmanager.gcp.upbound.io/test   True    True     projects/990150596479/secrets
/test/versions/2   2m12s

NAME                                       READY   SYNCED   EXTERNAL-NAME   AGE
secret.secretmanager.gcp.upbound.io/test   True    True     test            87m
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
