### PR TITLE
Make not-generated Terraform resources CSV available as a Github workflow artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,19 @@ jobs:
         run: make vendor vendor.check
 
       - name: Check Diff
-        run: make check-diff
+        run: |
+          mkdir _output
+          make check-diff
+        env:
+          # check-diff depends on the generate Make target, and we would like
+          # to save a skipped resource list
+          SKIPPED_RESOURCES_CSV: ../_output/skipped_resources.csv
+
+      - name: Publish skipped resources CSV to Github
+        uses: actions/upload-artifact@v3
+        with:
+          name: skipped_resources
+          path: _output/skipped_resources.csv
 
   unit-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: output
           path: _output/**

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -7,23 +21,28 @@ import (
 	"strings"
 
 	"github.com/upbound/upjet/pkg/pipeline"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/upbound/provider-gcp/config"
 )
 
 func main() {
-	if len(os.Args) < 2 || os.Args[1] == "" {
-		panic("root directory is required to be given as argument")
-	}
-	absRootDir, err := filepath.Abs(os.Args[1])
+	var (
+		app                 = kingpin.New("generator", "Run Upjet code generation pipelines for provider-gcp").DefaultEnvars()
+		repoRoot            = app.Arg("repo-root", "Root directory for the provider repository").Required().String()
+		skippedResourcesCSV = app.Flag("skipped-resources-csv", "File path where a list of skipped (not-generated) Terraform resource names will be stored as a CSV").Envar("SKIPPED_RESOURCES_CSV").String()
+	)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	absRootDir, err := filepath.Abs(*repoRoot)
 	if err != nil {
-		panic(fmt.Sprintf("cannot calculate the absolute path of %s", os.Args[1]))
+		panic(fmt.Sprintf("cannot calculate the absolute path with %s", *repoRoot))
 	}
 	p := config.GetProvider()
 	pipeline.Run(p, absRootDir)
-	if fp := os.Getenv("SKIPPED_RESOURCES_CSV"); len(fp) != 0 {
-		if err := os.WriteFile(fp, []byte(strings.Join(p.GetSkippedResourceNames(), ",")), 0o600); err != nil {
-			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", fp, err.Error()))
+	if len(*skippedResourcesCSV) != 0 {
+		if err := os.WriteFile(*skippedResourcesCSV, []byte(strings.Join(p.GetSkippedResourceNames(), "\n")), 0o600); err != nil {
+			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", *skippedResourcesCSV, err.Error()))
 		}
 	}
 }

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/upbound/upjet/pkg/pipeline"
 
@@ -18,5 +19,11 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("cannot calculate the absolute path of %s", os.Args[1]))
 	}
-	pipeline.Run(config.GetProvider(), absRootDir)
+	p := config.GetProvider()
+	pipeline.Run(p, absRootDir)
+	if fp := os.Getenv("SKIPPED_RESOURCES_CSV"); len(fp) != 0 {
+		if err := os.WriteFile(fp, []byte(strings.Join(p.GetSkippedResourceNames(), ",")), 0o600); err != nil {
+			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", fp, err.Error()))
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -142,3 +142,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/upbound/upjet => github.com/ulucinar/upbound-upjet v0.0.0-20221110144831-17aa3b94b882

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/crossplane/crossplane-tools v0.0.0-20220310165030-1f43fc12793e
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/pkg/errors v0.9.1
-	github.com/upbound/upjet v0.7.0
+	github.com/upbound/upjet v0.8.0-rc.0.0.20221111123128-6de200a3a8b0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
@@ -142,5 +142,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/upbound/upjet => github.com/ulucinar/upbound-upjet v0.0.0-20221110144831-17aa3b94b882

--- a/go.sum
+++ b/go.sum
@@ -648,8 +648,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/upbound/upjet v0.7.0 h1:DxfijsUHk5qhdpQemyQe0NYL89vbXgfoH85c5ma8rUA=
-github.com/upbound/upjet v0.7.0/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
+github.com/ulucinar/upbound-upjet v0.0.0-20221110144831-17aa3b94b882 h1:X8sBFqLPia9Wd5HB6CzdoGpwtZNd9wH2hv8x4nuCYCk=
+github.com/ulucinar/upbound-upjet v0.0.0-20221110144831-17aa3b94b882/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -648,8 +648,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/ulucinar/upbound-upjet v0.0.0-20221110144831-17aa3b94b882 h1:X8sBFqLPia9Wd5HB6CzdoGpwtZNd9wH2hv8x4nuCYCk=
-github.com/ulucinar/upbound-upjet v0.0.0-20221110144831-17aa3b94b882/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
+github.com/upbound/upjet v0.8.0-rc.0.0.20221111123128-6de200a3a8b0 h1:bYRc+p0Glihl+G+/3paLq9H/LiWUcEOqKZddQmyNrN0=
+github.com/upbound/upjet v0.8.0-rc.0.0.20221111123128-6de200a3a8b0/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/controller/appengine/application/zz_controller.go
+++ b/internal/controller/appengine/application/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudfunctions/function/zz_controller.go
+++ b/internal/controller/cloudfunctions/function/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudfunctions/functioniammember/zz_controller.go
+++ b/internal/controller/cloudfunctions/functioniammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/folder/zz_controller.go
+++ b/internal/controller/cloudplatform/folder/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/organizationiamauditconfig/zz_controller.go
+++ b/internal/controller/cloudplatform/organizationiamauditconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/organizationiamcustomrole/zz_controller.go
+++ b/internal/controller/cloudplatform/organizationiamcustomrole/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/organizationiammember/zz_controller.go
+++ b/internal/controller/cloudplatform/organizationiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/project/zz_controller.go
+++ b/internal/controller/cloudplatform/project/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/projectdefaultserviceaccounts/zz_controller.go
+++ b/internal/controller/cloudplatform/projectdefaultserviceaccounts/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/projectiamauditconfig/zz_controller.go
+++ b/internal/controller/cloudplatform/projectiamauditconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/projectiammember/zz_controller.go
+++ b/internal/controller/cloudplatform/projectiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/projectservice/zz_controller.go
+++ b/internal/controller/cloudplatform/projectservice/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/projectusageexportbucket/zz_controller.go
+++ b/internal/controller/cloudplatform/projectusageexportbucket/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/serviceaccount/zz_controller.go
+++ b/internal/controller/cloudplatform/serviceaccount/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/serviceaccountiammember/zz_controller.go
+++ b/internal/controller/cloudplatform/serviceaccountiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/serviceaccountkey/zz_controller.go
+++ b/internal/controller/cloudplatform/serviceaccountkey/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudplatform/servicenetworkingpeereddnsdomain/zz_controller.go
+++ b/internal/controller/cloudplatform/servicenetworkingpeereddnsdomain/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudrun/domainmapping/zz_controller.go
+++ b/internal/controller/cloudrun/domainmapping/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudrun/service/zz_controller.go
+++ b/internal/controller/cloudrun/service/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudrun/serviceiammember/zz_controller.go
+++ b/internal/controller/cloudrun/serviceiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudscheduler/job/zz_controller.go
+++ b/internal/controller/cloudscheduler/job/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/cloudtasks/queue/zz_controller.go
+++ b/internal/controller/cloudtasks/queue/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/composer/environment/zz_controller.go
+++ b/internal/controller/composer/environment/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/address/zz_controller.go
+++ b/internal/controller/compute/address/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/attacheddisk/zz_controller.go
+++ b/internal/controller/compute/attacheddisk/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/autoscaler/zz_controller.go
+++ b/internal/controller/compute/autoscaler/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/backendbucket/zz_controller.go
+++ b/internal/controller/compute/backendbucket/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/backendbucketsignedurlkey/zz_controller.go
+++ b/internal/controller/compute/backendbucketsignedurlkey/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/backendservice/zz_controller.go
+++ b/internal/controller/compute/backendservice/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/disk/zz_controller.go
+++ b/internal/controller/compute/disk/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/diskiammember/zz_controller.go
+++ b/internal/controller/compute/diskiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/diskresourcepolicyattachment/zz_controller.go
+++ b/internal/controller/compute/diskresourcepolicyattachment/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/externalvpngateway/zz_controller.go
+++ b/internal/controller/compute/externalvpngateway/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/firewall/zz_controller.go
+++ b/internal/controller/compute/firewall/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/firewallpolicy/zz_controller.go
+++ b/internal/controller/compute/firewallpolicy/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/firewallpolicyassociation/zz_controller.go
+++ b/internal/controller/compute/firewallpolicyassociation/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/firewallpolicyrule/zz_controller.go
+++ b/internal/controller/compute/firewallpolicyrule/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/forwardingrule/zz_controller.go
+++ b/internal/controller/compute/forwardingrule/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/globaladdress/zz_controller.go
+++ b/internal/controller/compute/globaladdress/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/globalforwardingrule/zz_controller.go
+++ b/internal/controller/compute/globalforwardingrule/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/globalnetworkendpoint/zz_controller.go
+++ b/internal/controller/compute/globalnetworkendpoint/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/globalnetworkendpointgroup/zz_controller.go
+++ b/internal/controller/compute/globalnetworkendpointgroup/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/havpngateway/zz_controller.go
+++ b/internal/controller/compute/havpngateway/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/healthcheck/zz_controller.go
+++ b/internal/controller/compute/healthcheck/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/httphealthcheck/zz_controller.go
+++ b/internal/controller/compute/httphealthcheck/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/httpshealthcheck/zz_controller.go
+++ b/internal/controller/compute/httpshealthcheck/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/image/zz_controller.go
+++ b/internal/controller/compute/image/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/imageiammember/zz_controller.go
+++ b/internal/controller/compute/imageiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instance/zz_controller.go
+++ b/internal/controller/compute/instance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instancefromtemplate/zz_controller.go
+++ b/internal/controller/compute/instancefromtemplate/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instancegroup/zz_controller.go
+++ b/internal/controller/compute/instancegroup/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instancegroupmanager/zz_controller.go
+++ b/internal/controller/compute/instancegroupmanager/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instancegroupnamedport/zz_controller.go
+++ b/internal/controller/compute/instancegroupnamedport/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instanceiammember/zz_controller.go
+++ b/internal/controller/compute/instanceiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/instancetemplate/zz_controller.go
+++ b/internal/controller/compute/instancetemplate/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/interconnectattachment/zz_controller.go
+++ b/internal/controller/compute/interconnectattachment/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/managedsslcertificate/zz_controller.go
+++ b/internal/controller/compute/managedsslcertificate/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/network/zz_controller.go
+++ b/internal/controller/compute/network/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/networkendpoint/zz_controller.go
+++ b/internal/controller/compute/networkendpoint/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/networkendpointgroup/zz_controller.go
+++ b/internal/controller/compute/networkendpointgroup/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/networkpeering/zz_controller.go
+++ b/internal/controller/compute/networkpeering/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/networkpeeringroutesconfig/zz_controller.go
+++ b/internal/controller/compute/networkpeeringroutesconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/nodegroup/zz_controller.go
+++ b/internal/controller/compute/nodegroup/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/nodetemplate/zz_controller.go
+++ b/internal/controller/compute/nodetemplate/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/packetmirroring/zz_controller.go
+++ b/internal/controller/compute/packetmirroring/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/perinstanceconfig/zz_controller.go
+++ b/internal/controller/compute/perinstanceconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/projectdefaultnetworktier/zz_controller.go
+++ b/internal/controller/compute/projectdefaultnetworktier/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/projectmetadata/zz_controller.go
+++ b/internal/controller/compute/projectmetadata/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/projectmetadataitem/zz_controller.go
+++ b/internal/controller/compute/projectmetadataitem/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionautoscaler/zz_controller.go
+++ b/internal/controller/compute/regionautoscaler/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionbackendservice/zz_controller.go
+++ b/internal/controller/compute/regionbackendservice/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regiondisk/zz_controller.go
+++ b/internal/controller/compute/regiondisk/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regiondiskiammember/zz_controller.go
+++ b/internal/controller/compute/regiondiskiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regiondiskresourcepolicyattachment/zz_controller.go
+++ b/internal/controller/compute/regiondiskresourcepolicyattachment/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionhealthcheck/zz_controller.go
+++ b/internal/controller/compute/regionhealthcheck/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regioninstancegroupmanager/zz_controller.go
+++ b/internal/controller/compute/regioninstancegroupmanager/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionnetworkendpointgroup/zz_controller.go
+++ b/internal/controller/compute/regionnetworkendpointgroup/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionperinstanceconfig/zz_controller.go
+++ b/internal/controller/compute/regionperinstanceconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionsslcertificate/zz_controller.go
+++ b/internal/controller/compute/regionsslcertificate/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regiontargethttpproxy/zz_controller.go
+++ b/internal/controller/compute/regiontargethttpproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regiontargethttpsproxy/zz_controller.go
+++ b/internal/controller/compute/regiontargethttpsproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/regionurlmap/zz_controller.go
+++ b/internal/controller/compute/regionurlmap/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/reservation/zz_controller.go
+++ b/internal/controller/compute/reservation/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/resourcepolicy/zz_controller.go
+++ b/internal/controller/compute/resourcepolicy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/route/zz_controller.go
+++ b/internal/controller/compute/route/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/router/zz_controller.go
+++ b/internal/controller/compute/router/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/routerinterface/zz_controller.go
+++ b/internal/controller/compute/routerinterface/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/routernat/zz_controller.go
+++ b/internal/controller/compute/routernat/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/securitypolicy/zz_controller.go
+++ b/internal/controller/compute/securitypolicy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/serviceattachment/zz_controller.go
+++ b/internal/controller/compute/serviceattachment/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/sslcertificate/zz_controller.go
+++ b/internal/controller/compute/sslcertificate/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/subnetwork/zz_controller.go
+++ b/internal/controller/compute/subnetwork/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/subnetworkiammember/zz_controller.go
+++ b/internal/controller/compute/subnetworkiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targetgrpcproxy/zz_controller.go
+++ b/internal/controller/compute/targetgrpcproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targethttpproxy/zz_controller.go
+++ b/internal/controller/compute/targethttpproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targethttpsproxy/zz_controller.go
+++ b/internal/controller/compute/targethttpsproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targetinstance/zz_controller.go
+++ b/internal/controller/compute/targetinstance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targetpool/zz_controller.go
+++ b/internal/controller/compute/targetpool/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targetsslproxy/zz_controller.go
+++ b/internal/controller/compute/targetsslproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/targettcpproxy/zz_controller.go
+++ b/internal/controller/compute/targettcpproxy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/urlmap/zz_controller.go
+++ b/internal/controller/compute/urlmap/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/vpngateway/zz_controller.go
+++ b/internal/controller/compute/vpngateway/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/compute/vpntunnel/zz_controller.go
+++ b/internal/controller/compute/vpntunnel/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/container/cluster/zz_controller.go
+++ b/internal/controller/container/cluster/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/container/nodepool/zz_controller.go
+++ b/internal/controller/container/nodepool/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/container/registry/zz_controller.go
+++ b/internal/controller/container/registry/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/containeranalysis/note/zz_controller.go
+++ b/internal/controller/containeranalysis/note/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/containeraws/cluster/zz_controller.go
+++ b/internal/controller/containeraws/cluster/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/containeraws/nodepool/zz_controller.go
+++ b/internal/controller/containeraws/nodepool/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/containerazure/client/zz_controller.go
+++ b/internal/controller/containerazure/client/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/containerazure/cluster/zz_controller.go
+++ b/internal/controller/containerazure/cluster/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/containerazure/nodepool/zz_controller.go
+++ b/internal/controller/containerazure/nodepool/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/datacatalog/entry/zz_controller.go
+++ b/internal/controller/datacatalog/entry/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/datacatalog/entrygroup/zz_controller.go
+++ b/internal/controller/datacatalog/entrygroup/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/agent/zz_controller.go
+++ b/internal/controller/dialogflowcx/agent/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/entitytype/zz_controller.go
+++ b/internal/controller/dialogflowcx/entitytype/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/environment/zz_controller.go
+++ b/internal/controller/dialogflowcx/environment/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/flow/zz_controller.go
+++ b/internal/controller/dialogflowcx/flow/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/intent/zz_controller.go
+++ b/internal/controller/dialogflowcx/intent/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/page/zz_controller.go
+++ b/internal/controller/dialogflowcx/page/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dialogflowcx/version/zz_controller.go
+++ b/internal/controller/dialogflowcx/version/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dns/managedzone/zz_controller.go
+++ b/internal/controller/dns/managedzone/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dns/policy/zz_controller.go
+++ b/internal/controller/dns/policy/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/dns/recordset/zz_controller.go
+++ b/internal/controller/dns/recordset/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/essentialcontacts/contact/zz_controller.go
+++ b/internal/controller/essentialcontacts/contact/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/eventarc/trigger/zz_controller.go
+++ b/internal/controller/eventarc/trigger/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/filestore/instance/zz_controller.go
+++ b/internal/controller/filestore/instance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/firebaserules/release/zz_controller.go
+++ b/internal/controller/firebaserules/release/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/firebaserules/ruleset/zz_controller.go
+++ b/internal/controller/firebaserules/ruleset/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/gkehub/membership/zz_controller.go
+++ b/internal/controller/gkehub/membership/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/healthcare/consentstore/zz_controller.go
+++ b/internal/controller/healthcare/consentstore/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/healthcare/dataset/zz_controller.go
+++ b/internal/controller/healthcare/dataset/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iap/webbackendserviceiammember/zz_controller.go
+++ b/internal/controller/iap/webbackendserviceiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iap/webiammember/zz_controller.go
+++ b/internal/controller/iap/webiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iap/webtypeappengineiammember/zz_controller.go
+++ b/internal/controller/iap/webtypeappengineiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iap/webtypecomputeiammember/zz_controller.go
+++ b/internal/controller/iap/webtypecomputeiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/defaultsupportedidpconfig/zz_controller.go
+++ b/internal/controller/identityplatform/defaultsupportedidpconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/inboundsamlconfig/zz_controller.go
+++ b/internal/controller/identityplatform/inboundsamlconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/oauthidpconfig/zz_controller.go
+++ b/internal/controller/identityplatform/oauthidpconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/tenant/zz_controller.go
+++ b/internal/controller/identityplatform/tenant/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/tenantdefaultsupportedidpconfig/zz_controller.go
+++ b/internal/controller/identityplatform/tenantdefaultsupportedidpconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/tenantinboundsamlconfig/zz_controller.go
+++ b/internal/controller/identityplatform/tenantinboundsamlconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/identityplatform/tenantoauthidpconfig/zz_controller.go
+++ b/internal/controller/identityplatform/tenantoauthidpconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/cryptokey/zz_controller.go
+++ b/internal/controller/kms/cryptokey/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/cryptokeyiammember/zz_controller.go
+++ b/internal/controller/kms/cryptokeyiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/keyring/zz_controller.go
+++ b/internal/controller/kms/keyring/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/keyringiammember/zz_controller.go
+++ b/internal/controller/kms/keyringiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/keyringimportjob/zz_controller.go
+++ b/internal/controller/kms/keyringimportjob/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/secretciphertext/zz_controller.go
+++ b/internal/controller/kms/secretciphertext/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/monitoring/alertpolicy/zz_controller.go
+++ b/internal/controller/monitoring/alertpolicy/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/monitoring/notificationchannel/zz_controller.go
+++ b/internal/controller/monitoring/notificationchannel/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/monitoring/uptimecheckconfig/zz_controller.go
+++ b/internal/controller/monitoring/uptimecheckconfig/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/notebooks/environment/zz_controller.go
+++ b/internal/controller/notebooks/environment/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/notebooks/instance/zz_controller.go
+++ b/internal/controller/notebooks/instance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/notebooks/instanceiammember/zz_controller.go
+++ b/internal/controller/notebooks/instanceiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/notebooks/runtime/zz_controller.go
+++ b/internal/controller/notebooks/runtime/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/notebooks/runtimeiammember/zz_controller.go
+++ b/internal/controller/notebooks/runtimeiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/osconfig/ospolicyassignment/zz_controller.go
+++ b/internal/controller/osconfig/ospolicyassignment/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/osconfig/patchdeployment/zz_controller.go
+++ b/internal/controller/osconfig/patchdeployment/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/oslogin/sshpublickey/zz_controller.go
+++ b/internal/controller/oslogin/sshpublickey/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/privateca/capool/zz_controller.go
+++ b/internal/controller/privateca/capool/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/privateca/capooliammember/zz_controller.go
+++ b/internal/controller/privateca/capooliammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/privateca/certificate/zz_controller.go
+++ b/internal/controller/privateca/certificate/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/privateca/certificateauthority/zz_controller.go
+++ b/internal/controller/privateca/certificateauthority/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/privateca/certificatetemplate/zz_controller.go
+++ b/internal/controller/privateca/certificatetemplate/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/privateca/certificatetemplateiammember/zz_controller.go
+++ b/internal/controller/privateca/certificatetemplateiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/litereservation/zz_controller.go
+++ b/internal/controller/pubsub/litereservation/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/litesubscription/zz_controller.go
+++ b/internal/controller/pubsub/litesubscription/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/litetopic/zz_controller.go
+++ b/internal/controller/pubsub/litetopic/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/schema/zz_controller.go
+++ b/internal/controller/pubsub/schema/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/subscription/zz_controller.go
+++ b/internal/controller/pubsub/subscription/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/subscriptioniammember/zz_controller.go
+++ b/internal/controller/pubsub/subscriptioniammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/topic/zz_controller.go
+++ b/internal/controller/pubsub/topic/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pubsub/topiciammember/zz_controller.go
+++ b/internal/controller/pubsub/topiciammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/redis/instance/zz_controller.go
+++ b/internal/controller/redis/instance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/secretmanager/secret/zz_controller.go
+++ b/internal/controller/secretmanager/secret/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/secretmanager/secretiammember/zz_controller.go
+++ b/internal/controller/secretmanager/secretiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/secretmanager/secretversion/zz_controller.go
+++ b/internal/controller/secretmanager/secretversion/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/servicenetworking/connection/zz_controller.go
+++ b/internal/controller/servicenetworking/connection/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sourcerepo/repository/zz_controller.go
+++ b/internal/controller/sourcerepo/repository/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sourcerepo/repositoryiammember/zz_controller.go
+++ b/internal/controller/sourcerepo/repositoryiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/spanner/database/zz_controller.go
+++ b/internal/controller/spanner/database/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/spanner/databaseiammember/zz_controller.go
+++ b/internal/controller/spanner/databaseiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/spanner/instance/zz_controller.go
+++ b/internal/controller/spanner/instance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/spanner/instanceiammember/zz_controller.go
+++ b/internal/controller/spanner/instanceiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sql/database/zz_controller.go
+++ b/internal/controller/sql/database/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sql/databaseinstance/zz_controller.go
+++ b/internal/controller/sql/databaseinstance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sql/sourcerepresentationinstance/zz_controller.go
+++ b/internal/controller/sql/sourcerepresentationinstance/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sql/sslcert/zz_controller.go
+++ b/internal/controller/sql/sslcert/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/sql/user/zz_controller.go
+++ b/internal/controller/sql/user/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/bucket/zz_controller.go
+++ b/internal/controller/storage/bucket/zz_controller.go
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/bucketaccesscontrol/zz_controller.go
+++ b/internal/controller/storage/bucketaccesscontrol/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/bucketacl/zz_controller.go
+++ b/internal/controller/storage/bucketacl/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/bucketiammember/zz_controller.go
+++ b/internal/controller/storage/bucketiammember/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/bucketobject/zz_controller.go
+++ b/internal/controller/storage/bucketobject/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/defaultobjectaccesscontrol/zz_controller.go
+++ b/internal/controller/storage/defaultobjectaccesscontrol/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/storage/defaultobjectacl/zz_controller.go
+++ b/internal/controller/storage/defaultobjectacl/zz_controller.go
@@ -52,6 +52,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a change where a CSV file of Terraform resource names which are available in the Terraform provider's schema but not generated as managed resources is produced and made available as a Github workflow artifact.


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with the following workflow run:
https://github.com/upbound/provider-gcp/actions/runs/3439134516
https://github.com/upbound/provider-gcp/actions/runs/3461113867