### PR TITLE
Remove Terraform-specific comments from secretmanager.SecretVersion's SecretDataSecretRef field

### DIFF
--- a/apis/secretmanager/v1beta1/zz_secretversion_types.go
+++ b/apis/secretmanager/v1beta1/zz_secretversion_types.go
@@ -54,7 +54,6 @@ type SecretVersionParameters struct {
 	Secret *string `json:"secret,omitempty" tf:"secret,omitempty"`
 
 	// The secret data. Must be no larger than 64KiB.
-	// Note: This property is sensitive and will not be displayed in the plan.
 	// +kubebuilder:validation:Required
 	SecretDataSecretRef v1.SecretKeySelector `json:"secretDataSecretRef" tf:"-"`
 

--- a/config/secretmanager/config.go
+++ b/config/secretmanager/config.go
@@ -24,5 +24,6 @@ func Configure(p *config.Provider) {
 			Type:      "Secret",
 			Extractor: common.ExtractResourceIDFuncPath,
 		}
+		r.MetaResource.ArgumentDocs["secret_data"] = `The secret data. Must be no larger than 64KiB.`
 	})
 }

--- a/package/crds/secretmanager.gcp.upbound.io_secretversions.yaml
+++ b/package/crds/secretmanager.gcp.upbound.io_secretversions.yaml
@@ -71,9 +71,7 @@ spec:
                     description: Secret Manager secret resource
                     type: string
                   secretDataSecretRef:
-                    description: 'The secret data. Must be no larger than 64KiB. Note:
-                      This property is sensitive and will not be displayed in the
-                      plan.'
+                    description: The secret data. Must be no larger than 64KiB.
                     properties:
                       key:
                         description: The key to select.


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes documentation for the `SecretDataSecretRef` field of `secretmanager.SecretVersion`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
`make reviewable` and observing the generated CRD documentation.