### PR TITLE
Use self-link for Cluster network/subnetwork selector

### DIFF
--- a/apis/container/v1beta1/zz_cluster_types.go
+++ b/apis/container/v1beta1/zz_cluster_types.go
@@ -422,6 +422,7 @@ type ClusterParameters struct {
 	// network to which the cluster is connected. For Shared VPC, set this to the self link of the
 	// shared network.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
@@ -508,6 +509,7 @@ type ClusterParameters struct {
 	// The name or self_link of the Google Compute Engine
 	// subnetwork in which the cluster's instances are launched.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 

--- a/apis/container/v1beta1/zz_generated.resolvers.go
+++ b/apis/container/v1beta1/zz_generated.resolvers.go
@@ -37,7 +37,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network),
-		Extract:      reference.ExternalName(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.NetworkRef,
 		Selector:     mg.Spec.ForProvider.NetworkSelector,
 		To: reference.To{
@@ -71,7 +71,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 	}
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Subnetwork),
-		Extract:      reference.ExternalName(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.SubnetworkRef,
 		Selector:     mg.Spec.ForProvider.SubnetworkSelector,
 		To: reference.To{

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -99,10 +99,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}, nil
 		}
 		r.References["network"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		r.References["subnetwork"] = config.Reference{
-			Type: "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
+			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork",
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "location")
 	})


### PR DESCRIPTION
### Description of your changes

Uses the self-link instead of the name to select the network and subnetwork.

Fixes #53:


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually, created a shared vpc and used the networkSelector to link to the correct project with the self-link.
