### PR TITLE
Test bigquery & dataflow group with uptest

### DIFF
--- a/examples/bigquery/connection.yaml
+++ b/examples/bigquery/connection.yaml
@@ -49,6 +49,7 @@ apiVersion: sql.gcp.upbound.io/v1beta1
 kind: DatabaseInstance
 metadata:
   annotations:
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-user.sh
     meta.upbound.io/example-id: bigquery/v1beta1/connection
   labels:
     testing.upbound.io/example-name: instance

--- a/examples/bigquery/reservationassignment.yaml
+++ b/examples/bigquery/reservationassignment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: primary
 spec:
   forProvider:
-    assignee: projects/zippy-parity-368910
+    assignee: projects/${data.cloudplatform_project.projectId}
     jobType: PIPELINE
     reservationSelector:
       matchLabels:

--- a/examples/bigquery/testhooks/delete-user.sh
+++ b/examples/bigquery/testhooks/delete-user.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+# Note(turkenf): We are getting "Invalid request since instance is not running" exception if user for
+# the databaseinstance got deleted before the user resource. This is a workaround for this
+# problem to make automated tests to work.
+${KUBECTL} delete user.sql.gcp.upbound.io -l testing.upbound.io/example-name=user


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR attempts to test the bigquery & dataflow groups with the uptest tooling.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The results are recorded in PR https://github.com/upbound/provider-gcp/pull/56.