### PR TITLE
Print coverage statistics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
           # to save a skipped resource list
           SKIPPED_RESOURCES_CSV: ../_output/skipped_resources.csv
 
+      - name: Report Statistics
+        run: head -1 _output/skipped_resources.csv
+
       - name: Publish skipped resources CSV to Github
         uses: actions/upload-artifact@v3
         with:

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -41,7 +41,10 @@ func main() {
 	p := config.GetProvider()
 	pipeline.Run(p, absRootDir)
 	if len(*skippedResourcesCSV) != 0 {
-		if err := os.WriteFile(*skippedResourcesCSV, []byte(strings.Join(p.GetSkippedResourceNames(), "\n")), 0o600); err != nil {
+		skippedCount := len(p.GetSkippedResourceNames())
+		totalCount := skippedCount + len(p.Resources)
+		summaryLine := fmt.Sprintf("Skipped, total, coverage: %d, %d, %.1f%%", skippedCount, totalCount, (1.0-float64(skippedCount)/float64(totalCount))*100)
+		if err := os.WriteFile(*skippedResourcesCSV, []byte(strings.Join(append([]string{summaryLine}, p.GetSkippedResourceNames()...), "\n")), 0o600); err != nil {
 			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", *skippedResourcesCSV, err.Error()))
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Prints a coverage statistics line in the CI pipeline. Some previous discussions are [here](https://github.com/upbound/provider-aws/pull/139).

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
A new step following the `Check Diff` step now prints the statistics in the `CI` Github workflow:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/9376684/203589935-5eca0216-3a9e-43b9-8b10-ba0c799fd359.png">

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
