### PR TITLE
Add a "Show diff" step to show diffs in case the make check-diff step fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
         run: make vendor vendor.check
 
       - name: Check Diff
+        id: check-diff
         run: |
           mkdir _output
           make check-diff
@@ -125,6 +126,10 @@ jobs:
           # check-diff depends on the generate Make target, and we would like
           # to save a skipped resource list
           SKIPPED_RESOURCES_CSV: ../_output/skipped_resources.csv
+
+      - name: Show diff
+        if: failure() && steps.check-diff.outcome == 'failure'
+        run: git diff
 
       - name: Report Statistics
         run: head -1 _output/skipped_resources.csv

--- a/Makefile
+++ b/Makefile
@@ -141,9 +141,8 @@ $(TERRAFORM_PROVIDER_SCHEMA): $(TERRAFORM)
 	@$(OK) generating provider schema for $(TERRAFORM_PROVIDER_SOURCE) $(TERRAFORM_PROVIDER_VERSION)
 
 pull-docs:
-	@if [ ! -d "$(WORK_DIR)/$(notdir $(TERRAFORM_PROVIDER_REPO))" ]; then \
-		git clone -c advice.detachedHead=false --depth 1 --filter=blob:none --branch "v$(TERRAFORM_PROVIDER_VERSION)" --sparse "$(TERRAFORM_PROVIDER_REPO)" "$(WORK_DIR)/$(notdir $(TERRAFORM_PROVIDER_REPO))"; \
-	fi
+	rm -fR "$(WORK_DIR)/$(notdir $(TERRAFORM_PROVIDER_REPO))"
+	git clone -c advice.detachedHead=false --depth 1 --filter=blob:none --branch "v$(TERRAFORM_PROVIDER_VERSION)" --sparse "$(TERRAFORM_PROVIDER_REPO)" "$(WORK_DIR)/$(notdir $(TERRAFORM_PROVIDER_REPO))";
 	@git -C "$(WORK_DIR)/$(notdir $(TERRAFORM_PROVIDER_REPO))" sparse-checkout set "$(TERRAFORM_DOCS_PATH)"
 
 generate.init: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds a `Show diff` step that's run if the `check-diff` step fails in the `CI` pipeline to show what content changes are failing the job.

Also, while working in the context of updating the Terraform provider plugin version, I realized we do not honor the declared Terraform provider version if the working directory for the Terraform provider repo already exists (under `.work`). Previously we were [removing](https://github.com/upbound/official-providers/blob/2fc9ad914fb2132dfdc9b4a2c4c91f90000cc5bd/scripts/scrape_metadata.sh#L8) this work directory as we are doing a sparse checkout. So, applied the same approach here.

Relevant PR: https://github.com/upbound/provider-aws/pull/176

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Please see here:
https://github.com/upbound/provider-gcp/actions/runs/3533055974/jobs/5928190113

And in case `check-diff` does not fail, this step is skipped:
https://github.com/upbound/provider-gcp/actions/runs/3533076220/jobs/5928239220