### PR TITLE
ManagedZone - Use selflink for peer_config and private_visibility_config

### DIFF
--- a/apis/dns/v1beta1/zz_generated.resolvers.go
+++ b/apis/dns/v1beta1/zz_generated.resolvers.go
@@ -23,7 +23,6 @@ import (
 	errors "github.com/pkg/errors"
 	v1beta1 "github.com/upbound/provider-gcp/apis/compute/v1beta1"
 	common "github.com/upbound/provider-gcp/config/common"
-	resource "github.com/upbound/upjet/pkg/resource"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -38,7 +37,7 @@ func (mg *ManagedZone) ResolveReferences(ctx context.Context, c client.Reader) e
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.PeeringConfig[i3].TargetNetwork); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PeeringConfig[i3].TargetNetwork[i4].NetworkURL),
-				Extract:      resource.ExtractResourceID(),
+				Extract:      common.SelfLinkExtractor(),
 				Reference:    mg.Spec.ForProvider.PeeringConfig[i3].TargetNetwork[i4].NetworkURLRef,
 				Selector:     mg.Spec.ForProvider.PeeringConfig[i3].TargetNetwork[i4].NetworkURLSelector,
 				To: reference.To{
@@ -58,7 +57,7 @@ func (mg *ManagedZone) ResolveReferences(ctx context.Context, c client.Reader) e
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.PrivateVisibilityConfig[i3].Networks); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrivateVisibilityConfig[i3].Networks[i4].NetworkURL),
-				Extract:      resource.ExtractResourceID(),
+				Extract:      common.SelfLinkExtractor(),
 				Reference:    mg.Spec.ForProvider.PrivateVisibilityConfig[i3].Networks[i4].NetworkURLRef,
 				Selector:     mg.Spec.ForProvider.PrivateVisibilityConfig[i3].Networks[i4].NetworkURLSelector,
 				To: reference.To{

--- a/apis/dns/v1beta1/zz_managedzone_types.go
+++ b/apis/dns/v1beta1/zz_managedzone_types.go
@@ -170,7 +170,7 @@ type NetworksParameters struct {
 	// This should be formatted like projects/{project}/global/networks/{network} or
 	// https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}
 	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	NetworkURL *string `json:"networkUrl,omitempty" tf:"network_url,omitempty"`
 
@@ -233,7 +233,7 @@ type TargetNetworkParameters struct {
 	// This should be formatted like projects/{project}/global/networks/{network} or
 	// https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}
 	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	NetworkURL *string `json:"networkUrl,omitempty" tf:"network_url,omitempty"`
 

--- a/config/dns/config.go
+++ b/config/dns/config.go
@@ -9,6 +9,16 @@ import (
 // Configure configures individual resources by adding custom
 // ResourceConfigurators.
 func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("google_dns_managed_zone", func(r *config.Resource) {
+		r.References["peering_config.target_network.network_url"] = config.Reference{
+			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+		r.References["private_visibility_config.networks.network_url"] = config.Reference{
+			Type:      "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+	})
 	p.AddResourceConfigurator("google_dns_policy", func(r *config.Resource) {
 		r.References["networks.network_url"] = config.Reference{
 			Type:              "github.com/upbound/provider-gcp/apis/compute/v1beta1.Network",


### PR DESCRIPTION
### Description of your changes

Uses a networkSelectors with the **selfLinkExtractor** to the ManagedZone. This change is needed to get the ManagedZone working with a shared vpc setup.

Fixes #64

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually, created a managed zone with the new selectors with networks in a different project.