### PR TITLE
ForwardingRule - Use selflink for ip_address, network, subnetwork and target selector

### DIFF
--- a/apis/compute/v1beta1/zz_forwardingrule_types.go
+++ b/apis/compute/v1beta1/zz_forwardingrule_types.go
@@ -96,16 +96,16 @@ type ForwardingRuleParameters struct {
 	// that has validateForProxyless field set to true.
 	// For Private Service Connect forwarding rules that forward traffic to
 	// Google APIs, IP address must be provided.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Address
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:type=Address
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	IPAddress *string `json:"ipAddress,omitempty" tf:"ip_address,omitempty"`
 
-	// Reference to a Address in compute to populate ipAddress.
+	// Reference to a Address to populate ipAddress.
 	// +kubebuilder:validation:Optional
 	IPAddressRef *v1.Reference `json:"ipAddressRef,omitempty" tf:"-"`
 
-	// Selector for a Address in compute to populate ipAddress.
+	// Selector for a Address to populate ipAddress.
 	// +kubebuilder:validation:Optional
 	IPAddressSelector *v1.Selector `json:"ipAddressSelector,omitempty" tf:"-"`
 
@@ -146,16 +146,16 @@ type ForwardingRuleParameters struct {
 	// the load balanced IP should belong to for this Forwarding Rule. If
 	// this field is not specified, the default network will be used.
 	// This field is only used for INTERNAL load balancing.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Network
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
-	// Reference to a Network in compute to populate network.
+	// Reference to a Network to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
 
-	// Selector for a Network in compute to populate network.
+	// Selector for a Network to populate network.
 	// +kubebuilder:validation:Optional
 	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
@@ -223,16 +223,16 @@ type ForwardingRuleParameters struct {
 	// If the network specified is in auto subnet mode, this field is
 	// optional. However, if the network is in custom subnet mode, a
 	// subnetwork must be specified.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.Subnetwork
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 
-	// Reference to a Subnetwork in compute to populate subnetwork.
+	// Reference to a Subnetwork to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
 
-	// Selector for a Subnetwork in compute to populate subnetwork.
+	// Selector for a Subnetwork to populate subnetwork.
 	// +kubebuilder:validation:Optional
 	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 
@@ -240,16 +240,16 @@ type ForwardingRuleParameters struct {
 	// The target must live in the same region as the forwarding rule.
 	// The forwarded traffic must be of a type appropriate to the target
 	// object.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionTargetHTTPProxy
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:type=RegionTargetHTTPProxy
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Target *string `json:"target,omitempty" tf:"target,omitempty"`
 
-	// Reference to a RegionTargetHTTPProxy in compute to populate target.
+	// Reference to a RegionTargetHTTPProxy to populate target.
 	// +kubebuilder:validation:Optional
 	TargetRef *v1.Reference `json:"targetRef,omitempty" tf:"-"`
 
-	// Selector for a RegionTargetHTTPProxy in compute to populate target.
+	// Selector for a RegionTargetHTTPProxy to populate target.
 	// +kubebuilder:validation:Optional
 	TargetSelector *v1.Selector `json:"targetSelector,omitempty" tf:"-"`
 }

--- a/apis/compute/v1beta1/zz_generated.resolvers.go
+++ b/apis/compute/v1beta1/zz_generated.resolvers.go
@@ -441,7 +441,7 @@ func (mg *ForwardingRule) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.IPAddress),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.IPAddressRef,
 		Selector:     mg.Spec.ForProvider.IPAddressSelector,
 		To: reference.To{
@@ -457,7 +457,7 @@ func (mg *ForwardingRule) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.NetworkRef,
 		Selector:     mg.Spec.ForProvider.NetworkSelector,
 		To: reference.To{
@@ -473,7 +473,7 @@ func (mg *ForwardingRule) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Subnetwork),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.SubnetworkRef,
 		Selector:     mg.Spec.ForProvider.SubnetworkSelector,
 		To: reference.To{
@@ -489,7 +489,7 @@ func (mg *ForwardingRule) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Target),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.TargetRef,
 		Selector:     mg.Spec.ForProvider.TargetSelector,
 		To: reference.To{

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -261,6 +261,22 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Type:      "RegionBackendService",
 			Extractor: common.PathSelfLinkExtractor,
 		}
+		r.References["ip_address"] = config.Reference{
+			Type:      "Address",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+		r.References["network"] = config.Reference{
+			Type:      "Network",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+		r.References["subnetwork"] = config.Reference{
+			Type:      "Subnetwork",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+		r.References["target"] = config.Reference{
+			Type:      "RegionTargetHTTPProxy",
+			Extractor: common.PathSelfLinkExtractor,
+		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})
 

--- a/package/crds/compute.gcp.upbound.io_forwardingrules.yaml
+++ b/package/crds/compute.gcp.upbound.io_forwardingrules.yaml
@@ -176,7 +176,7 @@ spec:
                       APIs, IP address must be provided.
                     type: string
                   ipAddressRef:
-                    description: Reference to a Address in compute to populate ipAddress.
+                    description: Reference to a Address to populate ipAddress.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -210,7 +210,7 @@ spec:
                     - name
                     type: object
                   ipAddressSelector:
-                    description: Selector for a Address in compute to populate ipAddress.
+                    description: Selector for a Address to populate ipAddress.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -289,7 +289,7 @@ spec:
                       balancing.
                     type: string
                   networkRef:
-                    description: Reference to a Network in compute to populate network.
+                    description: Reference to a Network to populate network.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -323,7 +323,7 @@ spec:
                     - name
                     type: object
                   networkSelector:
-                    description: Selector for a Network in compute to populate network.
+                    description: Selector for a Network to populate network.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -432,8 +432,7 @@ spec:
                       subnet mode, a subnetwork must be specified.
                     type: string
                   subnetworkRef:
-                    description: Reference to a Subnetwork in compute to populate
-                      subnetwork.
+                    description: Reference to a Subnetwork to populate subnetwork.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -467,8 +466,7 @@ spec:
                     - name
                     type: object
                   subnetworkSelector:
-                    description: Selector for a Subnetwork in compute to populate
-                      subnetwork.
+                    description: Selector for a Subnetwork to populate subnetwork.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -513,8 +511,8 @@ spec:
                       the target object.
                     type: string
                   targetRef:
-                    description: Reference to a RegionTargetHTTPProxy in compute to
-                      populate target.
+                    description: Reference to a RegionTargetHTTPProxy to populate
+                      target.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -548,8 +546,8 @@ spec:
                     - name
                     type: object
                   targetSelector:
-                    description: Selector for a RegionTargetHTTPProxy in compute to
-                      populate target.
+                    description: Selector for a RegionTargetHTTPProxy to populate
+                      target.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the


### PR DESCRIPTION
### Description of your changes
Use selflink to resolve the Address, Network, SubNetwork and the Target resources in ForwardingRules.

Fixes #68 

-->

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've tested my changes manually by creating a ForwardingRule which selected the Address, Network, SubNetwork and the RegionTargetHTTPProxy with the matchlabel selector in a SharedVPC environment.