### PR TITLE
RegionTargetHTTPProxy - Use selflink for resolving RegionURLMap

### DIFF
--- a/apis/compute/v1beta1/zz_generated.resolvers.go
+++ b/apis/compute/v1beta1/zz_generated.resolvers.go
@@ -1719,7 +1719,7 @@ func (mg *RegionTargetHTTPProxy) ResolveReferences(ctx context.Context, c client
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.URLMap),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.URLMapRef,
 		Selector:     mg.Spec.ForProvider.URLMapSelector,
 		To: reference.To{

--- a/apis/compute/v1beta1/zz_regiontargethttpproxy_types.go
+++ b/apis/compute/v1beta1/zz_regiontargethttpproxy_types.go
@@ -58,16 +58,16 @@ type RegionTargetHTTPProxyParameters struct {
 
 	// A reference to the RegionUrlMap resource that defines the mapping from URL
 	// to the BackendService.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-gcp/apis/compute/v1beta1.RegionURLMap
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:type=RegionURLMap
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	URLMap *string `json:"urlMap,omitempty" tf:"url_map,omitempty"`
 
-	// Reference to a RegionURLMap in compute to populate urlMap.
+	// Reference to a RegionURLMap to populate urlMap.
 	// +kubebuilder:validation:Optional
 	URLMapRef *v1.Reference `json:"urlMapRef,omitempty" tf:"-"`
 
-	// Selector for a RegionURLMap in compute to populate urlMap.
+	// Selector for a RegionURLMap to populate urlMap.
 	// +kubebuilder:validation:Optional
 	URLMapSelector *v1.Selector `json:"urlMapSelector,omitempty" tf:"-"`
 }

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -310,6 +310,12 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_region_target_http_proxy", func(r *config.Resource) {
 		config.MarkAsRequired(r.TerraformResource, "region")
+
+		r.References["url_map"] = config.Reference{
+			Type:      "RegionURLMap",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+
 	})
 
 	p.AddResourceConfigurator("google_compute_region_url_map", func(r *config.Resource) {

--- a/package/crds/compute.gcp.upbound.io_regiontargethttpproxies.yaml
+++ b/package/crds/compute.gcp.upbound.io_regiontargethttpproxies.yaml
@@ -82,8 +82,7 @@ spec:
                       the mapping from URL to the BackendService.
                     type: string
                   urlMapRef:
-                    description: Reference to a RegionURLMap in compute to populate
-                      urlMap.
+                    description: Reference to a RegionURLMap to populate urlMap.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -117,8 +116,7 @@ spec:
                     - name
                     type: object
                   urlMapSelector:
-                    description: Selector for a RegionURLMap in compute to populate
-                      urlMap.
+                    description: Selector for a RegionURLMap to populate urlMap.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the


### PR DESCRIPTION
### Description of your changes

Use selflink to resolve RegionURLMap instead of resource id.

Fixes #82 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've tested it manually by creating a new RegionTargetHTTPProxy, which managed to resolve the correct RegionURLMap with the urlMapSelector without hardcoding it's resource ID.
