### PR TITLE
Address - Use selflink instead of resource ID

### DIFF
--- a/apis/compute/v1beta1/zz_address_types.go
+++ b/apis/compute/v1beta1/zz_address_types.go
@@ -63,6 +63,7 @@ type AddressParameters struct {
 	// can only be used with INTERNAL type with the VPC_PEERING and
 	// IPSEC_INTERCONNECT purposes.
 	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
@@ -103,6 +104,7 @@ type AddressParameters struct {
 	// This field can only be used with INTERNAL type with
 	// GCE_ENDPOINT/DNS_RESOLVER purposes.
 	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 

--- a/apis/compute/v1beta1/zz_generated.resolvers.go
+++ b/apis/compute/v1beta1/zz_generated.resolvers.go
@@ -40,7 +40,7 @@ func (mg *Address) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network),
-		Extract:      reference.ExternalName(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.NetworkRef,
 		Selector:     mg.Spec.ForProvider.NetworkSelector,
 		To: reference.To{
@@ -56,7 +56,7 @@ func (mg *Address) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Subnetwork),
-		Extract:      reference.ExternalName(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.SubnetworkRef,
 		Selector:     mg.Spec.ForProvider.SubnetworkSelector,
 		To: reference.To{

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -65,10 +65,12 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_address", func(r *config.Resource) {
 		r.References["network"] = config.Reference{
-			Type: "Network",
+			Type:      "Network",
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		r.References["subnetwork"] = config.Reference{
-			Type: "Subnetwork",
+			Type:      "Subnetwork",
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})


### PR DESCRIPTION
### Description of your changes
Use selflink instead of resource ID when resolving SubNetwork from an Address resource.


-->
Fixes #88 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I was testing my changes manually by building and pushing a new image to our repository. Once I deployed the new provider the Address resource was created successfully.
