### PR TITLE
Add configuration of datalossprevention (4), dataplex (1), dataproc (10), datastore (1), deploymentmanager (1), dialogflow (4) groups

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -166,4 +166,63 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	//
 	// Imported by using the following format: projects/{{project}}/locations/global/keys/{{name}}
 	"google_apikeys_key": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/locations/global/keys/{{ .external_name }}"),
+	// datalossprevention
+	//
+	// Imported by using the following format: {{parent}}/deidentifyTemplates/{{name}}
+	"google_data_loss_prevention_deidentify_template": config.IdentifierFromProvider,
+	// Imported by using the following format: {{parent}}/inspectTemplates/{{name}}
+	"google_data_loss_prevention_inspect_template": config.IdentifierFromProvider,
+	// Imported by using the following format: {{parent}}/jobTriggers/{{name}}
+	"google_data_loss_prevention_job_trigger": config.IdentifierFromProvider,
+	// Imported by using the following format: {{parent}}/storedInfoTypes/{{name}}
+	"google_data_loss_prevention_stored_info_type": config.IdentifierFromProvider,
+
+	// dataplex
+	//
+	// Imported by using the following format: projects/{{project}}/locations/{{location}}/lakes/{{name}}
+	"google_dataplex_lake": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/locations/{{ .parameters.location }}/lakes/{{ .external_name }}"),
+
+	// dataproc
+	//
+	// Imported by using the following format: projects/{{project}}/locations/{{location}}/autoscalingPolicies/{{policy_id}}
+	"google_dataproc_autoscaling_policy": config.TemplatedStringAsIdentifier("policy_id", "projects/{{ .setup.configuration.project }}/locations/{{ .parameters.location }}/autoscalingPolicies/{{ .external_name }}"),
+	// No Import
+	"google_dataproc_cluster": config.IdentifierFromProvider,
+	// Imported by using the following format: projects/{project}/regions/{region}/clusters/{cluster} roles/editor
+	"google_dataproc_cluster_iam_binding": config.TemplatedStringAsIdentifier("cluster", "projects/{ .setup.configuration.project }/regions/{{ .parameters.region }}/clusters/{{ .external_name }} {{ .parameters.role }}"),
+	// Imported by using the following format: projects/{project}/regions/{region}/clusters/{cluster} roles/editor user:jane@example.com
+	"google_dataproc_cluster_iam_member": config.TemplatedStringAsIdentifier("cluster", "projects/{ .setup.configuration.project }/regions/{{ .parameters.region }}/clusters/{{ .external_name }} {{ .parameters.role }} {{ .parameters.member }}"),
+	// Imported by using the following format: projects/{project}/regions/{region}/clusters/{cluster}
+	"google_dataproc_cluster_iam_policy": config.TemplatedStringAsIdentifier("cluster", "projects/{ .setup.configuration.project }/regions/{{ .parameters.region }}/clusters/{{ .external_name }}"),
+	// No Import
+	"google_dataproc_job": config.IdentifierFromProvider,
+	// Imported by using the following format: projects/{project}/regions/{region}/jobs/{job_id} roles/editor
+	"google_dataproc_job_iam_binding": config.TemplatedStringAsIdentifier("job_id", "projects/{ .setup.configuration.project }/regions/{{ .parameters.region }}/jobs/{{ .external_name }} {{ .parameters.role }}"),
+	// Imported by using the following format: projects/{project}/regions/{region}/jobs/{job_id} roles/editor user:jane@example.com
+	"google_dataproc_job_iam_member": config.TemplatedStringAsIdentifier("job_id", "projects/{ .setup.configuration.project }/regions/{{ .parameters.region }}/jobs/{{ .external_name }} {{ .parameters.role }} {{ .parameters.member }}"),
+	// Imported by using the following format: projects/{project}/regions/{region}/jobs/{job_id}
+	"google_dataproc_job_iam_policy": config.TemplatedStringAsIdentifier("job_id", "projects/{ .setup.configuration.project }/regions/{{ .parameters.region }}/jobs/{{ .external_name }}"),
+	// Imported by using the following format: projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}
+	"google_dataproc_workflow_template": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/locations/{{ .parameters.location }}/workflowTemplates/{{ .external_name }}"),
+
+	// datastore
+	//
+	// Imported by using the following format: projects/{{project}}/indexes/{{index_id}}
+	"google_datastore_index": config.IdentifierFromProvider,
+
+	// deploymentmanager
+	//
+	// Imported by using the following format: projects/{{project}}/deployments/{{name}}
+	"google_deployment_manager_deployment": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/deployments/{{ .external_name }}"),
+
+	// dialogflow
+	//
+	// Imported by using the following format: {{project}}
+	"google_dialogflow_agent": config.ParameterAsIdentifier("project"),
+	// Imported by using the following format: {{name}}
+	"google_dialogflow_entity_type": config.IdentifierFromProvider,
+	// Imported by using the following format: {{name}}
+	"google_dialogflow_fulfillment": config.IdentifierFromProvider,
+	// Imported by using the following format: {{name}}
+	"google_dialogflow_intent": config.IdentifierFromProvider,
 }


### PR DESCRIPTION

<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add configuration of 4 resources in the `datalossprevention` group:
- [x] [`google_data_loss_prevention_deidentify_template`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/data_loss_prevention_deidentify_template)
- [x] [`google_data_loss_prevention_inspect_template`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/data_loss_prevention_inspect_template)
- [x] [`google_data_loss_prevention_job_trigger`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/data_loss_prevention_job_trigger)
- [x] [`google_data_loss_prevention_stored_info_type`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/data_loss_prevention_stored_info_type)

Add configuration of 1 resources in the `dataplex` group:
- [x] [`google_dataplex_lake`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataplex_lake)

Add configuration of 10 resources in the `dataproc` group:
- [x] [`google_dataproc_autoscaling_policy`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_autoscaling_policy)
- [x] [`google_dataproc_cluster`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_cluster)
- [x] [`google_dataproc_cluster_iam_binding`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_cluster_iam)
- [x] [`google_dataproc_cluster_iam_member`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_cluster_iam)
- [x] [`google_dataproc_cluster_iam_policy`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_cluster_iam)
- [x] [`google_dataproc_job`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_job)
- [x] [`google_dataproc_job_iam_binding`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_job_iam)
- [x] [`google_dataproc_job_iam_member`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_job_iam)
- [x] [`google_dataproc_job_iam_policy`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_job_iam)
- [x] [`google_dataproc_workflow_template`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_workflow_template)

Add configuration of 1 resources in the `datastore` group:
- [x] [`google_datastore_index`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/datastore_index)

Add configuration of 1 resources in the `deploymentmanager` group:
- [x] [`google_deployment_manager_deployment`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/deployment_manager_deployment)

Add configuration of 4 resources in the `dialogflow` group:
- [x] [`google_dialogflow_agent`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_agent)
- [x] [`google_dialogflow_entity_type`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_entity_type)
- [x] [`google_dialogflow_fulfillment`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_fulfillment)
- [x] [`google_dialogflow_intent`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_intent)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #19 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
