### PR TITLE
Improve examples and test some resources

### DIFF
--- a/examples/kms/cryptokey.yaml
+++ b/examples/kms/cryptokey.yaml
@@ -1,0 +1,31 @@
+apiVersion: kms.gcp.upbound.io/v1beta1
+kind: CryptoKey
+metadata:
+  annotations:
+    meta.upbound.io/example-id: kms/v1beta1/cryptokey
+    upjet.upbound.io/manual-intervention: "By default, keys in Cloud KMS spend 24 hours in the Scheduled for destruction (soft deleted) state before the key material is logically deleted from the system"
+  labels:
+    testing.upbound.io/example-name: crypto-key
+  name: crypto-key-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    keyRingSelector:
+      matchLabels:
+        testing.upbound.io/example-name: keyring
+    rotationPeriod: 100000s
+    # The minimum duration is 24 hours for all keys, except for import-only keys which have a minimum duration of 0
+    destroyScheduledDuration: 86400s
+---
+
+apiVersion: kms.gcp.upbound.io/v1beta1
+kind: KeyRing
+metadata:
+  annotations:
+    meta.upbound.io/example-id: kms/v1beta1/cryptokey
+    upjet.upbound.io/manual-intervention: "This resource is dependency of CryptoKey. This resource is skipping because parent resource was skipped."
+  labels:
+    testing.upbound.io/example-name: keyring
+  name: keyring-crypto-key-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    location: global

--- a/examples/sql/testhooks/delete-user.sh
+++ b/examples/sql/testhooks/delete-user.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+# Note(turkenf): We are getting (Invalid request since instance is not running) exception if user for
+# the instance got deleted before the user resource. This is a workaround for this
+# problem to make automated tests to work.
+${KUBECTL} delete user.sql.gcp.upbound.io -l testing.upbound.io/example-name=example_user

--- a/examples/sql/user.yaml
+++ b/examples/sql/user.yaml
@@ -2,7 +2,6 @@ apiVersion: sql.gcp.upbound.io/v1beta1
 kind: User
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "Depends on SQL instance to be successfully deleted"
     meta.upbound.io/example-id: sql/v1beta1/user
   labels:
     testing.upbound.io/example-name: example_user
@@ -25,9 +24,32 @@ data:
 kind: Secret
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "Depends on SQL instance to be successfully deleted"
     meta.upbound.io/example-id: sql/v1beta1/user
   labels:
     testing.upbound.io/example-name: example_user
   name: example-sql-user
   namespace: upbound-system
+
+---
+
+apiVersion: sql.gcp.upbound.io/v1beta1
+kind: DatabaseInstance
+metadata:
+  annotations:
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-user.sh
+    meta.upbound.io/example-id: sql/v1beta1/user
+  labels:
+    testing.upbound.io/example-name: example_instance
+  # ${Rand...} is not valid YAML and is used with automated testing
+  name: example-instance-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: "us-central1"
+    databaseVersion: "MYSQL_5_7"
+    settings:
+      - tier: "db-f1-micro"
+        diskSize: 20
+    deletionProtection: false # allow crossplane to delete the instance automatically
+  writeConnectionSecretToRef:
+    name: example-sql-db-instance-secret
+    namespace: upbound-system


### PR DESCRIPTION
### Description of your changes

Test some resources after v4.22.0 -> v4.48.0 version bump

Fixes: https://github.com/upbound/provider-gcp/issues/154

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- `examples/pubsub/subscription.yaml`
Subscription -> https://github.com/upbound/provider-gcp/actions/runs/3968234524
Topic -> https://github.com/upbound/provider-gcp/actions/runs/3968234524
- `examples/sql/user.yaml`
User -> https://github.com/upbound/provider-gcp/actions/runs/3983975011
DatabaseInstance -> https://github.com/upbound/provider-gcp/actions/runs/3983975011
- `examples/compute/network.yaml`
Network -> https://github.com/upbound/provider-gcp/actions/runs/3968743433
- `examples/compute/subnetwork.yaml`
Subnetwork -> https://github.com/upbound/provider-gcp/actions/runs/3968940827
Network -> https://github.com/upbound/provider-gcp/actions/runs/3968940827
- `examples/storage/bucketiammember.yaml`
BucketIAMMember -> https://github.com/upbound/provider-gcp/actions/runs/3969343284
Bucket -> https://github.com/upbound/provider-gcp/actions/runs/3969343284
- `examples/kms/keyringiammember.yaml`
KeyRingIAMMember -> https://github.com/upbound/provider-gcp/actions/runs/3969503294
KeyRing -> https://github.com/upbound/provider-gcp/actions/runs/3969503294
- `examples/kms/cryptokey.yaml`
```shell
NAME                                                  READY   SYNCED   EXTERNAL-NAME            AGE
cryptokey.kms.gcp.upbound.io/crypto-key-op-yamf9eqz   True    True     crypto-key-op-yamf9eqz   88s

NAME                                                        READY   SYNCED   EXTERNAL-NAME                    AGE
keyring.kms.gcp.upbound.io/keyring-crypto-key-op-uq8jveeh   True    True     keyring-crypto-key-op-uq8jveeh   88s
```