### PR TITLE
Instance - Use selflink instead of resourceId

### DIFF
--- a/apis/compute/v1beta1/zz_generated.resolvers.go
+++ b/apis/compute/v1beta1/zz_generated.resolvers.go
@@ -733,7 +733,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.NetworkInterface); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkInterface[i3].Network),
-			Extract:      reference.ExternalName(),
+			Extract:      common.SelfLinkExtractor(),
 			Reference:    mg.Spec.ForProvider.NetworkInterface[i3].NetworkRef,
 			Selector:     mg.Spec.ForProvider.NetworkInterface[i3].NetworkSelector,
 			To: reference.To{
@@ -751,7 +751,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.NetworkInterface); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkInterface[i3].Subnetwork),
-			Extract:      reference.ExternalName(),
+			Extract:      common.SelfLinkExtractor(),
 			Reference:    mg.Spec.ForProvider.NetworkInterface[i3].SubnetworkRef,
 			Selector:     mg.Spec.ForProvider.NetworkInterface[i3].SubnetworkSelector,
 			To: reference.To{

--- a/apis/compute/v1beta1/zz_instance_types.go
+++ b/apis/compute/v1beta1/zz_instance_types.go
@@ -492,6 +492,7 @@ type NetworkInterfaceParameters struct {
 	// Either network or subnetwork must be provided. If network isn't provided it will
 	// be inferred from the subnetwork.
 	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
@@ -528,6 +529,7 @@ type NetworkInterfaceParameters struct {
 	// network is in auto subnet mode, specifying the subnetwork is optional. If the network is
 	// in custom subnet mode, specifying the subnetwork is required.
 	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
 

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -125,10 +125,12 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Schema["labels"].Elem = schema.TypeString
 
 		r.References["network_interface.network"] = config.Reference{
-			Type: "Network",
+			Type:      "Network",
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		r.References["network_interface.subnetwork"] = config.Reference{
-			Type: "Subnetwork",
+			Type:      "Subnetwork",
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		r.References["boot_disk.initialize_params.image"] = config.Reference{
 			Type: "Image",


### PR DESCRIPTION
### Description of your changes

Use selflink when resolving Network and SubNetwork from an Instance resource instead of resourceId.

Fixes #195 

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've built an image with my changes and set it up as the gcp-provider in our environment. With the new images the Instance creation was successful.
