### PR TITLE
Bumps dependencies used in Github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v2.0.0
+        uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.png", "**.jpg"]'
@@ -79,17 +79,17 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(make go.cachedir)"
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-lint-
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -126,17 +126,17 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(make go.cachedir)"
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-check-diff-
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -189,17 +189,17 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(make go.cachedir)"
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-unit-tests-
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -229,7 +229,7 @@ jobs:
           platforms: all
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
           install: true
@@ -257,17 +257,17 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(make go.cachedir)"
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-publish-artifacts-
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/uptest-all.yml
+++ b/.github/workflows/uptest-all.yml
@@ -31,7 +31,7 @@ jobs:
           print(list[1:]); \
           ")
           echo "Api Groups: $OUTPUT"
-          echo "::set-output name=list::${OUTPUT}"
+          echo "list=${OUTPUT}" >> $GITHUB_OUTPUT
 
   uptest:
     runs-on: ubuntu-22.04
@@ -49,7 +49,7 @@ jobs:
           platforms: all
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
           install: true
@@ -69,17 +69,17 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(go env GOCACHE)"
+        run: echo "cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-uptest-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-build-uptest-
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -101,7 +101,7 @@ jobs:
           cd ..
           EXAMPLE_LIST=""
           EXAMPLE_LIST="${EXAMPLE_LIST},$(find ${{ matrix.api-groups }} -name '*.yaml' | tr '\n' ',')"
-          echo "::set-output name=example-list::${EXAMPLE_LIST:1}"
+          echo "example-list=${EXAMPLE_LIST:1}" >> $GITHUB_OUTPUT
           echo "Examples: ${EXAMPLE_LIST:1}"
 
       - name: Run Uptest


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Bumps `fkirc/skip-duplicate-actions` Github action to v5.3.0. Also remove usages of the deprecated `set-output` and `save-state` Github commands:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

We also bump the `actions/cache` and the `docker/setup-buildx-action` actions to `v3` and `v2`, respectively, as the current versions make use of the deprecated `save-state` command.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The new dependency's been available in this run:
https://github.com/upbound/provider-aws/actions/runs/4111881233/jobs/7096129032

<img width="365" alt="image" src="https://user-images.githubusercontent.com/9376684/217191201-477a43c3-74e0-471f-8e7f-90b3eadf8008.png">

And in the following run with an amended commit, the jobs were successfully skipped:
https://github.com/upbound/provider-aws/actions/runs/4111973225/jobs/7096326530

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/9376684/217193646-448c9e79-ec93-4d15-81c0-be96c671c033.png">

Regarding the `actions/cache` dependency, Github no longer complains about the deprecated `save-state` command in the logs of the steps using this action and a cached item was successfully restored as the logs below show:

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/9376684/217206974-f7c8b206-5272-4e9e-95b3-869cc94e9eb7.png">
