### PR TITLE
Add enable_autopilot attribute and some another attributes  to LateInitializer ignore to fix issue 256

### DIFF
--- a/apis/container/v1beta1/zz_generated_terraformed.go
+++ b/apis/container/v1beta1/zz_generated_terraformed.go
@@ -89,9 +89,20 @@ func (tr *Cluster) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AddonsConfig.DNSCacheConfig"))
+	opts = append(opts, resource.WithNameFilter("AddonsConfig.GCPFilestoreCsiDriverConfig"))
+	opts = append(opts, resource.WithNameFilter("AddonsConfig.NetworkPolicyConfig"))
+	opts = append(opts, resource.WithNameFilter("ClusterAutoscaling.Enabled"))
+	opts = append(opts, resource.WithNameFilter("ClusterAutoscaling.ResourceLimits"))
 	opts = append(opts, resource.WithNameFilter("ClusterIPv4Cidr"))
+	opts = append(opts, resource.WithNameFilter("DefaultMaxPodsPerNode"))
+	opts = append(opts, resource.WithNameFilter("EnableAutopilot"))
+	opts = append(opts, resource.WithNameFilter("EnableIntranodeVisibility"))
+	opts = append(opts, resource.WithNameFilter("EnableShieldedNodes"))
 	opts = append(opts, resource.WithNameFilter("IPAllocationPolicy"))
+	opts = append(opts, resource.WithNameFilter("NetworkPolicy"))
 	opts = append(opts, resource.WithNameFilter("NodeVersion"))
+	opts = append(opts, resource.WithNameFilter("WorkloadIdentityConfig"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -22,6 +22,17 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				"cluster_ipv4_cidr",
 				"ip_allocation_policy",
 				"node_version",
+				"enable_autopilot",
+				"workload_identity_config",
+				"addons_config.network_policy_config",
+				"addons_config.gcp_filestore_csi_driver_config",
+				"addons_config.dns_cache_config",
+				"default_max_pods_per_node",
+				"cluster_autoscaling.enabled",
+				"cluster_autoscaling.resource_limits",
+				"enable_intranode_visibility",
+				"network_policy",
+				"enable_shielded_nodes",
 			},
 		}
 		config.MoveToStatus(r.TerraformResource, "node_pool")

--- a/examples/container/cluster.yaml
+++ b/examples/container/cluster.yaml
@@ -8,6 +8,7 @@ metadata:
   name: cluster
 spec:
   forProvider:
-    initialNodeCount: 1
-    location: us-central1-a
-    removeDefaultNodePool: false
+    location: europe-north1
+    ipAllocationPolicy:
+      - {}
+    enableAutopilot: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add next attributes to LateInitializer ignore:

"enable_autopilot",
"workload_identity_config",
"addons_config.network_policy_config",
"addons_config.gcp_filestore_csi_driver_config",
"addons_config.dns_cache_config",
"default_max_pods_per_node",
"cluster_autoscaling.enabled",
"cluster_autoscaling.resource_limits",
"enable_intranode_visibility",
"network_policy",
"enable_shielded_nodes"

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #https://github.com/upbound/provider-gcp/issues/256

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Uptest: https://github.com/upbound/provider-gcp/actions/runs/4477290409/jobs/7868644634

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
