### PR TITLE
InterconnectAttachment - Use selflink instead of Id

### DIFF
--- a/apis/compute/v1beta1/zz_generated.resolvers.go
+++ b/apis/compute/v1beta1/zz_generated.resolvers.go
@@ -1084,7 +1084,7 @@ func (mg *InterconnectAttachment) ResolveReferences(ctx context.Context, c clien
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Router),
-		Extract:      common.ExtractResourceID(),
+		Extract:      common.SelfLinkExtractor(),
 		Reference:    mg.Spec.ForProvider.RouterRef,
 		Selector:     mg.Spec.ForProvider.RouterSelector,
 		To: reference.To{

--- a/apis/compute/v1beta1/zz_interconnectattachment_types.go
+++ b/apis/compute/v1beta1/zz_interconnectattachment_types.go
@@ -262,7 +262,7 @@ type InterconnectAttachmentParameters struct {
 	// automatically connect the Interconnect to the network & region within which the
 	// Cloud Router is configured.
 	// +crossplane:generate:reference:type=Router
-	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Router *string `json:"router,omitempty" tf:"router,omitempty"`
 

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -212,7 +212,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	p.AddResourceConfigurator("google_compute_interconnect_attachment", func(r *config.Resource) {
 		r.References["router"] = config.Reference{
 			Type:      "Router",
-			Extractor: common.ExtractResourceIDFuncPath,
+			Extractor: common.PathSelfLinkExtractor,
 		}
 		config.MarkAsRequired(r.TerraformResource, "region")
 	})


### PR DESCRIPTION
### Description of your changes

Use selflink when resolving Router from an InterconnectAttachment resource instead of resourceId.

Fixes #290 

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've built an image with my changes and set it up as the gcp-provider in our environment. With the new images the InterconnectAttachment creation was successful.
