### PR TITLE
Add maintenance_version field to ignore list

### DIFF
--- a/apis/sql/v1beta1/zz_generated_terraformed.go
+++ b/apis/sql/v1beta1/zz_generated_terraformed.go
@@ -163,6 +163,7 @@ func (tr *DatabaseInstance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("MaintenanceVersion"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -37,6 +37,9 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		// NOTE(@tnthornton) most of the connection details that were exported
 		// to the connection details secret are marked as non-sensitive for tf.
 		// We need to manually construct the secret details for those items.
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"maintenance_version"},
+		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			if a, ok := attr["connection_name"].(string); ok {


### PR DESCRIPTION
### Description of your changes

Fixes #297 

This PR adds `maintenance_version` field to ignore list in the context of late-init

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually validated.
