### PR TITLE
Fix Publish Service Artifacts workflow call

### DIFF
--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -12,12 +12,12 @@ on:
         required: true
       size:
         description: "Number of smaller provider packages to build and push with each build job"
+        default: '30'
         required: true
-        default: 30
       concurrency:
         description: "Number of parallel package builds within each build job"
-        optional: true
-        default: 1
+        default: '1'
+        required: false
 
 jobs:
   publish-service-artifacts:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relevant PR: https://github.com/upbound/uptest/pull/110

This PR removes the `optional: true` specification in the inputs of the `Publish Service Artifacts` reusable workflow call and converts types of `size` and `concurrency` input parameters from `number` to `string`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Please see: https://github.com/upbound/provider-gcp/actions/runs/4963402570