### PR TITLE
Rename family parent package from provider-gcp-config to provider-family-gcp

### DIFF
--- a/cluster/images/provider-gcp/Makefile
+++ b/cluster/images/provider-gcp/Makefile
@@ -68,7 +68,7 @@ batch-process: $(UP)
 		--platform $(BATCH_PLATFORMS) \
 		--provider-name $(PROJECT_NAME) \
 		--family-package-url-format $(XPKG_REG_ORGS)/%s:$(VERSION) \
-		--package-repo-override monolith=$(PROJECT_NAME) --package-repo-override config=provider-$(PROVIDER_NAME)-config \
+		--package-repo-override monolith=$(PROJECT_NAME) --package-repo-override config=provider-family-$(PROVIDER_NAME) \
 		--provider-bin-root $(OUTPUT_DIR)/bin \
 		--output-dir $(XPKG_OUTPUT_DIR) \
 		--store-packages $(STORE_PACKAGE) \

--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Name }}
 {{ if ne .Service "monolith" }}
   labels:
-    pkg.crossplane.io/provider-family: provider-{{ .ProviderName }}-config
+    pkg.crossplane.io/provider-family: provider-family-{{ .ProviderName }}
 {{ end }}
   annotations:
     meta.crossplane.io/maintainer: Upbound <support@upbound.io>
@@ -23,6 +23,6 @@ metadata:
 {{ if and (ne .Service "config") (ne .Service "monolith") -}}
 spec:
   dependsOn:
-    - provider: {{ .XpkgRegOrg }}/provider-{{ .ProviderName }}-config
+    - provider: {{ .XpkgRegOrg }}/provider-family-{{ .ProviderName }}
       version: "{{ .DepConstraint }}"
 {{ end }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a renaming of the family parent package from `provider-gcp-config` to `provider-family-gcp`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Validated in https://github.com/upbound/provider-azure/pull/452.