### PR TITLE
Fix minor issue in docs for creating a Cronjob for rotate the GCP access tokens

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -423,7 +423,7 @@ spec:
                 - |-
                   kubectl create secret generic $SECRET_NAME \
                     --dry-run=client \
-                    --from-literal=$SECRET_KEY=\$(gcloud auth print-access-token) \
+                    --from-literal=$SECRET_KEY=$(gcloud auth print-access-token) \
                     -o yaml | kubectl apply -f -
               resources:
                 requests:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This is only a documentation change, with the current guide, I obtained an error running the Job:
```
kubectl logs -n crossplane cred-sync-001-tc4xk                                                                                                   ─╯
/bin/bash: -c: line 3: syntax error near unexpected token `('
```
This was fixed with the proposed change. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I tested the proposed change in a test GCP cluster running k8s v1.24.11.