### PR TITLE
Do not assume private_key attribute exists in ServiceAccountKey state

### DIFF
--- a/config/cloudplatform/config.go
+++ b/config/cloudplatform/config.go
@@ -61,6 +61,9 @@ func Configure(p *config.Provider) {
 		// Therefore, writing it as a connection Secret results in the Secret value being double encoded,
 		// so decode it and add to the connection details as private_key
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
+			if attr["private_key"] == nil {
+				return nil, nil
+			}
 			privateKeyEncoded, err := common.GetField(attr, "private_key")
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #307 

We currently [assume](https://github.com/upbound/provider-gcp/blob/43d33c797f4368ae126438cda6be165720e965fa/config/cloudplatform/config.go#LL64C13-L64C13) that the `private_key` attribute always exists in the observed tfstate for the `ServiceAccountKey.cloudplatform` resource. However, this may not always be true. This PR proposes a fix that first checks the existence of this attribute in the observed state.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually tested by:
1. Provision a `ServiceAccountKey.cloudplatform` resource
2. Destroy the associated Terraform workspace
3. Make sure the resource is reconciled and it still has the `Synced: True` status condition.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
