### PR TITLE
Remove family label from the config provider for proper search indexing

### DIFF
--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
   name: {{ .Name }}
-{{ if ne .Service "monolith" }}
+{{ if and (ne .Service "config") (ne .Service "monolith") }}
   labels:
     pkg.crossplane.io/provider-family: provider-family-{{ .ProviderName }}
 {{ end }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
To support Upbound Marketplace search indexing behaviour, the family label should only be applied on subpackages and not the config provider.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Confirmed by building xpkg and extracting annotated layer that the label is _only_ present on subpackages:

```
  labels:
    pkg.crossplane.io/provider-family: provider-family-gcp
 ```
 
