### PR TITLE
Adds the required field `spec.projectID` for ProviderConfig creation …

### DIFF
--- a/package/auth.yaml
+++ b/package/auth.yaml
@@ -33,6 +33,7 @@ sources:
         ref: spec.credentials.secretRef
     showFields:
       - spec.credentials.secretRef
+      - spec.projectID
   - name: Upbound
     docs: |
       # OpenID Connect (OIDC)
@@ -75,3 +76,4 @@ sources:
       for more information on configuring OIDC with Upbound and GCP.
     showFields:
       - spec.credentials.upbound
+      - spec.projectID

--- a/package/auth.yaml
+++ b/package/auth.yaml
@@ -55,7 +55,7 @@ sources:
       1. Select **Add a provider to pool** and then select **OpenID Connect (OIDC)** with the following details.
       ```
       Provider Name: upbound-oidc-provider
-      Provider ID: upbound-oidc-provider-id
+      Provider ID: upbound-oidc-provider (by default, this will be the same as the provider name)
       Issuer (URL): https://proidc.upbound.io
       ```
       2. Select **Allowed audiences** and add `sts.googleapis.com` for **Audience 1**.
@@ -71,7 +71,21 @@ sources:
       ```
       google.subject.contains("mcp:<ORGANIZATION_NAME>")
       ```
+
+      ## Create and grant access to service account
       
+      To access GCP resources, pool identities will need to be granted access to a service account.
+      The service account email will be used to create the ProviderConfig.
+
+      Create the service account by following the steps in [Create a GCP Service Account](https://docs.upbound.io/quickstart/gcp-deploy/#create-a-gcp-service-account).
+
+      To add the service account to the Workload Identity pool:
+
+      1. Return to the Workload Identity Federation page and select your pool.
+      2. Near the top of the page select Grant Access.
+      3. Select the new service account, upbound-service-account.
+      4. Under Select principals use All identities in the pool.
+
       See the [Upbound documentation](https://docs.upbound.io/quickstart/gcp-deploy/#connect-to-gcp-with-oidc)
       for more information on configuring OIDC with Upbound and GCP.
     showFields:


### PR DESCRIPTION
…in Upbound

<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

In Upbound, `package/auth.yaml` is used to configure what fields are exposed to create `ProviderConfig` objects. The required field `spec.projectID` was missing for GCP.

-->
Fixes #https://github.com/upbound/squad-upbound-cloud/issues/1248

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Built and pushed a package with this change and updated my personal Configuration's dependencies in Upbound to use the artifact.
- Verified the projectID field is exposed and a ProviderConfig can be created.
![Screen Shot 2023-06-14 at 11 20 10 AM](https://github.com/upbound/provider-gcp/assets/2058247/016712da-c7dd-4074-88bf-92e9b60f7bfd)
![Screen Shot 2023-06-14 at 11 27 09 AM](https://github.com/upbound/provider-gcp/assets/2058247/59807aba-84ba-40b6-b3f7-c2b1c5c4f436)

