### PR TITLE
Fixes a typo on the required format for an identity provider when usi…

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -63,7 +63,7 @@ type Upbound struct {
 type Federation struct {
 	// ProviderID is the fully-qualified identifier for the identity provider on
 	// GCP. The format is
-	// `project/<project-id>/locations/global/workloadIdentityPools/<identity-pool>/providers/<identity-provider>`.
+	// `projects/<project-id>/locations/global/workloadIdentityPools/<identity-pool>/providers/<identity-provider>`.
 	// +kubebuilder:validation:MinLength=1
 	ProviderID string `json:"providerID"`
 	// ServiceAccount is the email address for the attached service account.

--- a/package/crds/gcp.upbound.io_providerconfigs.yaml
+++ b/package/crds/gcp.upbound.io_providerconfigs.yaml
@@ -119,7 +119,7 @@ spec:
                         properties:
                           providerID:
                             description: ProviderID is the fully-qualified identifier
-                              for the identity provider on GCP. The format is `project/<project-id>/locations/global/workloadIdentityPools/<identity-pool>/providers/<identity-provider>`.
+                              for the identity provider on GCP. The format is `projects/<project-id>/locations/global/workloadIdentityPools/<identity-pool>/providers/<identity-provider>`.
                             minLength: 1
                             type: string
                           serviceAccount:


### PR DESCRIPTION
…ng workload identity federation.

<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Fixes a typo that gets rendered in API documentation and the Upbound console which can lead to user error when configuring OIDC.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n/a
