### PR TITLE
Temporarily disable configuring auth with secrets

### DIFF
--- a/package/auth.yaml
+++ b/package/auth.yaml
@@ -1,39 +1,6 @@
 version: '2023-01-30'
 discriminant: spec.credentials.source
 sources:
-  - name: Secret
-    docs: |
-      # Storing Credentials as a Kubernetes Secret
-      
-      GCP credentials may be supplied as a Kubernetes `Secret`. Credentials will
-      be stored in this control plane and will only be accessible to installed
-      providers.
-      
-      Credentials should be provided in the following format as a GCP Service Account keyfile:
-      ```
-      {
-        "type": "service_account",
-        "project_id": "PROJECT_ID",
-        "private_key_id": "KEY_ID",
-        "private_key": "-----BEGIN PRIVATE KEY-----\nPRIVATE_KEY\n-----END PRIVATE KEY-----\n",
-        "client_email": "SERVICE_ACCOUNT_EMAIL",
-        "client_id": "CLIENT_ID",
-        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-        "token_uri": "https://accounts.google.com/o/oauth2/token",
-        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICE_ACCOUNT_EMAIL"
-      }
-      ```
-      
-      See the [GCP
-      documentation](https://cloud.google.com/iam/docs/keys-create-delete)
-      for more information on how to generate credentials.
-    additionalResources:
-      - type: Secret
-        ref: spec.credentials.secretRef
-    showFields:
-      - spec.credentials.secretRef
-      - spec.projectID
   - name: Upbound
     docs: |
       # OpenID Connect (OIDC)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Remove the auth source of "Secret" to temporarily disable storing user credentials as Kubernetes secrets as we harden our security posture for the console.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Local build and deploy to control plane: https://console.upbound.io/upbound/controlPlanes/upbound:gcp-no-secrets. Tested create, edit, and delete functionality.

Note that there is no longer a dropdown to select the `source` as there is only one option (Upbound OIDC).
