### PR TITLE
fix(cluster): skip lateInit for node_config

### DIFF
--- a/apis/container/v1beta1/zz_generated_terraformed.go
+++ b/apis/container/v1beta1/zz_generated_terraformed.go
@@ -101,6 +101,7 @@ func (tr *Cluster) LateInitialize(attrs []byte) (bool, error) {
 	opts = append(opts, resource.WithNameFilter("EnableShieldedNodes"))
 	opts = append(opts, resource.WithNameFilter("IPAllocationPolicy"))
 	opts = append(opts, resource.WithNameFilter("NetworkPolicy"))
+	opts = append(opts, resource.WithNameFilter("NodeConfig"))
 	opts = append(opts, resource.WithNameFilter("NodeVersion"))
 	opts = append(opts, resource.WithNameFilter("WorkloadIdentityConfig"))
 

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -21,6 +21,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			IgnoredFields: []string{
 				"cluster_ipv4_cidr",
 				"ip_allocation_policy",
+				"node_config",
 				"node_version",
 				"enable_autopilot",
 				"workload_identity_config",


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
skip lateInit for node_config

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #335

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
kubectl get managed | grep "gcp.upbound.io"
serviceaccount.cloudplatform.gcp.upbound.io/nodepool   True    True     nodepool        29m
cluster.container.gcp.upbound.io/nodepool   True    True     nodepool        29m
nodepool.container.gcp.upbound.io/nodepool   True    True     nodepool        29m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
