### PR TITLE
Fix the external-name configuration for the ProjectSink.logging resource

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -902,7 +902,7 @@ var externalNameConfigs = map[string]config.ExternalName{
 	"google_logging_project_exclusion": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/exclusions/{{ .external_name }}"),
 	// Project-level logging sinks can be imported using their URI
 	// projects/my-project/sinks/my-sink
-	"google_logging_project_sink": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/sinks/{{ .external_name }}"),
+	"google_logging_project_sink": config.TemplatedStringAsIdentifier("name", "projects/{{ if .parameters.project }}{{ .parameters.project }}{{ else }}{{ .setup.configuration.project }}{{ end }}/sinks/{{ .external_name }}"),
 
 	// vertexai
 	//


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We have an external-name configuration error for the `ProjectSink.logging` resource as reported [here](https://github.com/upbound/provider-gcp/issues/275). This PR fixes the issue for this specific resource and we will need to scan the configurations of other resources and also fix them.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I've validated the fix by using the service account credentials and @stevendborrelli has verified it in Upbound Cloud via the federated credentials.
The provider packages used for validation are: `index.docker.io/ulucinar/provider-gcp-{logging,pubsub}:v0.36.0-rc.0.1.g1523f4b6` and `index.docker.io/ulucinar/provider-family-gcp:v0.36.0-rc.0.1.g1523f4b6`.