### PR TITLE
Ignore node_count and initial_node_count when late initializing NodePools

### DIFF
--- a/apis/container/v1beta1/zz_generated_terraformed.go
+++ b/apis/container/v1beta1/zz_generated_terraformed.go
@@ -198,6 +198,8 @@ func (tr *NodePool) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("InitialNodeCount"))
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -127,5 +127,11 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Type:      "Cluster",
 			Extractor: common.ExtractResourceIDFuncPath,
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{
+				"initial_node_count",
+				"node_count",
+			},
+		}
 	})
 }


### PR DESCRIPTION
Having `node_count` late-initialized with autoscaling can cause the autoscaler and Crossplane to fight over how many nodes there should be (with Crossplane effectively reverting autoscaler changes). If autoscaling is used, `node_count` should remain unset.

[As documented], `initial_node_count` may (or may not?) change if the node count is manually changed (via gcloud or the Cloud Console). This can cause resources to fail reconciliation because terraform wants to destroy and recreate the node pool. If the node count is changed manually, either Crossplane should correct it back to the value of an explicitly set `node_count` field, or it should be ignored because autoscaler is in use (in which case `node_count` should be unset).

[As documented]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#initial_node_count

Fixes #340

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review (sort of - the linter was OOMing, but the tests pass when run separately).

### How has this code been tested

Manually exercised with `make run` against minikube by creating a Cluster and Node Pool with autoscaling enabled, and manually (in Cloud Console) setting the node count to a high number such that the autoscaler scales it back down (which is how I found the issue with `initial_node_count` beyond the main issue in #340). I repeated this process a few times, and did not see any errors or attempts to undo the autoscaler's actions.
