### PR TITLE
Fix panic on DatabaseInstance failing to create

### DIFF
--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -55,7 +55,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				conn[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(a)
 			}
 			// map
-			if certSlice, ok := attr["server_ca_cert"].([]interface{}); ok {
+			if certSlice, ok := attr["server_ca_cert"].([]interface{}); ok && len(certSlice) > 0 {
 				if certattrs, ok := certSlice[0].(map[string]interface{}); ok {
 					if a, ok := certattrs["cert"].(string); ok {
 						conn[CloudSQLSecretServerCACertificateCertKey] = []byte(a)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

In some cases when a DatabaseInstance fails to create, such as when it cannot create a subnetwork if there's no IP space available, a panic would occur as there's no certificate info in the certSlice. Fixed this by just checking if the certSlice is empty.

Fixes #343 

I have:

- [X] Run `make reviewable test` to ensure this PR is ready for review. (just ran `make test` as the rest fails)

### How has this code been tested

Tested the following scenarios:
- Successful creation of DatabaseInstance: confirmed certificate details are still added to `status.atProvider.serverCaCert`
- Failed creation does not cause panic anymore and does not add certificate details to `status.atProvider.serverCaCert`. Status condition is still added with the error from GCP.