### PR TITLE
Inherit golangci-lint version from `build` submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 export GOPRIVATE = github.com/upbound/*
 
 GO_REQUIRED_VERSION ?= 1.19
-GOLANGCILINT_VERSION ?= 1.50.0
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+# GOLANGCILINT_VERSION ?= 1.54.0
+
 # SUBPACKAGES ?= $(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3)
 SUBPACKAGES ?= monolith
 GO_STATIC_PACKAGES ?= $(GO_PROJECT)/cmd/generator ${SUBPACKAGES:%=$(GO_PROJECT)/cmd/provider/%}


### PR DESCRIPTION


<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Motivation: golangci-lint base run was freezing on Mac M1 and go1.20.5.
* Remove the version override in the Makefile with the comment and consume the latest version from the build
* Presumably, it was a fix around consume a lot of memory on go1.20rc3 consume a lot of memory on go1.20rc3 golangci/golangci-lint#3470 helped in the latest golangci-lint release
* Update build submodule to consume https://github.com/upbound/build/pull/238

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`rm -rf .cache`
```
make lint
15:21:34 [ .. ] verify go modules dependencies have expected content
all modules verified
15:21:34 [ OK ] go modules dependencies verified
15:21:35 [ .. ] installing golangci-lint-v1.54.0 darwin-arm64
15:21:36 [ OK ] installing golangci-lint-v1.54.0 darwin-arm64
15:21:36 [ .. ] golangci-lint
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
15:23:16 [ OK ] golangci-lint
```