### PR TITLE
Use spec.forProvider.project if it exists instead of the ProviderConfig's spec.projectID

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -902,7 +902,7 @@ var externalNameConfigs = map[string]config.ExternalName{
 	"google_logging_project_exclusion": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/exclusions/{{ .external_name }}"),
 	// Project-level logging sinks can be imported using their URI
 	// projects/my-project/sinks/my-sink
-	"google_logging_project_sink": config.TemplatedStringAsIdentifier("name", "projects/{{ .setup.configuration.project }}/sinks/{{ .external_name }}"),
+	"google_logging_project_sink": config.TemplatedStringAsIdentifier("name", "projects/{{ if .parameters.project }}{{ .parameters.project }}{{ else }}{{ .setup.configuration.project }}{{ end }}/sinks/{{ .external_name }}"),
 
 	// vertexai
 	//


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Cherry-pick of https://github.com/upbound/provider-gcp/pull/352 & https://github.com/upbound/provider-gcp/pull/350 for the `release-0.35` branch.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Please refer to https://github.com/upbound/provider-gcp/pull/352.