### PR TITLE
Add ability to publish family provider docs for updoc workflow

### DIFF
--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -1,17 +1,12 @@
 name: Updoc
 
 on:
-  workflow_dispatch:
-    inputs:
-      subpackages:
-        description: "Subpackages to be published individually (e.g. monolith config ec2)"
-        default: "monolith"
-        required: false
+  workflow_dispatch: {}
 
 jobs:
   publish-docs:
     uses: upbound/uptest/.github/workflows/provider-updoc.yml@main
     with:
-      subpackages: ${{ github.event.inputs.subpackages }}
+      providers: "monolith config"
     secrets:
       UPBOUND_CI_PROD_BUCKET_SA: ${{ secrets.UPBOUND_CI_PROD_BUCKET_SA }}

--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -1,10 +1,17 @@
 name: Updoc
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      subpackages:
+        description: "Subpackages to be published individually (e.g. monolith config ec2)"
+        default: "monolith"
+        required: false
 
 jobs:
   publish-docs:
     uses: upbound/uptest/.github/workflows/provider-updoc.yml@main
+    with:
+      subpackages: ${{ github.event.inputs.subpackages }}
     secrets:
       UPBOUND_CI_PROD_BUCKET_SA: ${{ secrets.UPBOUND_CI_PROD_BUCKET_SA }}


### PR DESCRIPTION
### Description of your changes

Consumes reusable workflows introduced in https://github.com/upbound/uptest/pull/134

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on `turkenf/uptest` and `turkenf/provider-gcp`
