### PR TITLE
Add addons_config.gcs_fuse_csi_driver_config to ignore list for late-…

### DIFF
--- a/apis/container/v1beta1/zz_generated_terraformed.go
+++ b/apis/container/v1beta1/zz_generated_terraformed.go
@@ -101,6 +101,7 @@ func (tr *Cluster) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("AddonsConfig.DNSCacheConfig"))
 	opts = append(opts, resource.WithNameFilter("AddonsConfig.GCPFilestoreCsiDriverConfig"))
+	opts = append(opts, resource.WithNameFilter("AddonsConfig.GcsFuseCsiDriverConfig"))
 	opts = append(opts, resource.WithNameFilter("AddonsConfig.NetworkPolicyConfig"))
 	opts = append(opts, resource.WithNameFilter("ClusterAutoscaling.Enabled"))
 	opts = append(opts, resource.WithNameFilter("ClusterAutoscaling.ResourceLimits"))

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -27,6 +27,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				"workload_identity_config",
 				"addons_config.network_policy_config",
 				"addons_config.gcp_filestore_csi_driver_config",
+				"addons_config.gcs_fuse_csi_driver_config",
 				"addons_config.dns_cache_config",
 				"default_max_pods_per_node",
 				"cluster_autoscaling.enabled",


### PR DESCRIPTION
…init

### Description of your changes

Added `addons_config.gcs_fuse_csi_driver_config` to ignore list for late init.
Fixes #403

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Local testing
- upjet tests `examples/container/cluster.yaml`
