### PR TITLE
Add IP address(host) to secret for `Instance.redis`

### DIFF
--- a/config/redis/config.go
+++ b/config/redis/config.go
@@ -7,5 +7,12 @@ import "github.com/upbound/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_redis_instance", func(r *config.Resource) {
 		config.MarkAsRequired(r.TerraformResource, "region")
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["host"].(string); ok {
+				conn["host"] = []byte(a)
+			}
+			return conn, nil
+		}
 	})
 }

--- a/examples/redis/instance.yaml
+++ b/examples/redis/instance.yaml
@@ -14,3 +14,6 @@ spec:
     labels:
       environment: dev
     authEnabled: true
+  writeConnectionSecretToRef:
+    name: example-redis-instance-secret
+    namespace: upbound-system


### PR DESCRIPTION
### Description of your changes

This PR adds IP address to secret for `Instance.redis` resource.

Fixes: https://github.com/upbound/provider-gcp/issues/387

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually:
```
> k describe secret example-redis-instance-secret -n upbound-system
Name:         example-redis-instance-secret
Namespace:    upbound-system
Labels:       <none>
Annotations:  <none>

Type:  connection.crossplane.io/v1alpha1

Data
====
host:                   13 bytes
attribute.auth_string:  36 bytes
```
