### PR TITLE
Use family providers in uptest instead of monolith

### DIFF
--- a/cluster/images/provider-gcp/Makefile
+++ b/cluster/images/provider-gcp/Makefile
@@ -25,12 +25,14 @@ img.build:
 	@$(INFO) Family base image to build: $(IMAGE)
 	@$(INFO) Building image $${IMAGE}; \
 	$(MAKE) BUILD_ARGS="--load ${BUILD_ARGS}" IMAGE=$${IMAGE} XPKG_REG_ORGS=$(XPKG_REG_ORGS) img.build.shared; \
-	if [[ "$${LOAD_MONOLITH}" == "true" ]]; then \
-	  $(MAKE) batch-process SUBPACKAGES=monolith BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGE=monolith && \
-	  export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-monolith-$(VERSION).xpkg") && \
-	  docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-monolith-$(ARCH); \
+	if [[ "$${LOAD_PACKAGES}" == "true" ]]; then \
+		$(MAKE) batch-process SUBPACKAGES="$(SUBPACKAGES)" BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGES="$$(tr ' ' ',' <<< "$(SUBPACKAGES)")" && \
+		for s in $(SUBPACKAGES); do \
+			export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-$${s}-$(VERSION).xpkg") && \
+			docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-$${s}-$(ARCH); \
+		done; \
 	fi || $(FAIL)
-	@$(OK) docker build $${IMAGE};
+	@$(OK) docker build $${IMAGE}
 
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
@@ -59,11 +61,11 @@ ifeq (-,$(findstring -,$(VERSION)))
     DEP_CONSTRAINT = >= 0.0.0-0
 endif
 BUILD_ONLY ?= false
-STORE_PACKAGE ?= ""
+STORE_PACKAGES ?= ""
 batch-process: $(UP)
-	@$(INFO) Batch processing smaller provider packages for: $(SUBPACKAGES)
+	@$(INFO) Batch processing smaller provider packages for: "$(SUBPACKAGES)"
 	@mkdir -p "$(XPKG_OUTPUT_DIR)/$(PLATFORM)" && \
-	$(UP) xpkg batch --smaller-providers $$(echo -n $(SUBPACKAGES) | tr ' ' ',') \
+	$(UP) xpkg batch --smaller-providers "$$(tr ' ' ',' <<< "$(SUBPACKAGES)")" \
 		--family-base-image $(BUILD_REGISTRY)/$(PROJECT_NAME) \
 		--platform $(BATCH_PLATFORMS) \
 		--provider-name $(PROJECT_NAME) \
@@ -71,7 +73,7 @@ batch-process: $(UP)
 		--package-repo-override monolith=$(PROJECT_NAME) --package-repo-override config=provider-family-$(PROVIDER_NAME) \
 		--provider-bin-root $(OUTPUT_DIR)/bin \
 		--output-dir $(XPKG_OUTPUT_DIR) \
-		--store-packages $(STORE_PACKAGE) \
+		--store-packages "$(STORE_PACKAGES)" \
 		--build-only=$(BUILD_ONLY) \
 		--examples-root $(ROOT_DIR)/examples \
 		--examples-group-override monolith=* --examples-group-override config=providerconfig \
@@ -82,4 +84,4 @@ batch-process: $(UP)
 		--template-var XpkgRegOrg=$(XPKG_REG_ORGS) --template-var DepConstraint="$(DEP_CONSTRAINT)" --template-var ProviderName=$(PROVIDER_NAME) \
 		--concurrency $(CONCURRENCY) \
 		--push-retry 10 || $(FAIL)
-	@$(OK) Done processing smaller provider packages for: $(SUBPACKAGES)
+	@$(OK) Done processing smaller provider packages for: "$(SUBPACKAGES)"


### PR DESCRIPTION
### Description of your changes

Use family providers in uptest instead of monolith. Related PR: https://github.com/upbound/provider-aws/pull/903

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally via `make family-e2e`
