### PR TITLE
fix: NodePool should not late-init node count

### DIFF
--- a/apis/container/v1beta1/zz_generated_terraformed.go
+++ b/apis/container/v1beta1/zz_generated_terraformed.go
@@ -264,6 +264,8 @@ func (tr *NodePool) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("InitialNodeCount"))
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -130,6 +130,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Type:      "Cluster",
 			Extractor: common.ExtractResourceIDFuncPath,
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{
+				"node_count",
+				"initial_node_count",
+			},
+		}
 
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if diff == nil || diff.Destroy {


### PR DESCRIPTION
The nodepool's `node_count` and `initial_node_count` should not be late-initialized to prevent a fight with the GKE autoscaler.

Also see  discussion on #353

Fixes: #340

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<WIP>

