### PR TITLE
fix: add version to lateinit ingore array

### DIFF
--- a/apis/container/v1beta1/zz_generated_terraformed.go
+++ b/apis/container/v1beta1/zz_generated_terraformed.go
@@ -264,6 +264,7 @@ func (tr *NodePool) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -126,6 +126,11 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 	p.AddResourceConfigurator("google_container_node_pool", func(r *config.Resource) {
 		r.Kind = "NodePool"
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{
+				"version",
+			},
+		}
 		r.References["cluster"] = config.Reference{
 			Type:      "Cluster",
 			Extractor: common.ExtractResourceIDFuncPath,


### PR DESCRIPTION
<!--
Thank you for helping to improve Official GCP Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official GCP Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add the version field of nodepools to be ignored during the late-init process.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official GCP Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #249 hopefully

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
