### PR TITLE
Add SSA merge strategy to container NodePool's nodeConfig to avoid fights over ownership.

### DIFF
--- a/apis/container/v1beta1/zz_generated.deepcopy.go
+++ b/apis/container/v1beta1/zz_generated.deepcopy.go
@@ -8968,6 +8968,11 @@ func (in *NodePoolNodeConfigInitParameters_2) DeepCopyInto(out *NodePoolNodeConf
 		*out = new(string)
 		**out = **in
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.KubeletConfig != nil {
 		in, out := &in.KubeletConfig, &out.KubeletConfig
 		*out = make([]NodePoolNodeConfigKubeletConfigInitParameters, len(*in))
@@ -9722,6 +9727,11 @@ func (in *NodePoolNodeConfigObservation_2) DeepCopyInto(out *NodePoolNodeConfigO
 		*out = new(string)
 		**out = **in
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.KubeletConfig != nil {
 		in, out := &in.KubeletConfig, &out.KubeletConfig
 		*out = make([]NodePoolNodeConfigKubeletConfigObservation, len(*in))
@@ -9977,6 +9987,11 @@ func (in *NodePoolNodeConfigParameters_2) DeepCopyInto(out *NodePoolNodeConfigPa
 	}
 	if in.ImageType != nil {
 		in, out := &in.ImageType, &out.ImageType
+		*out = new(string)
+		**out = **in
+	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/container/v1beta1/zz_nodepool_types.go
+++ b/apis/container/v1beta1/zz_nodepool_types.go
@@ -214,6 +214,8 @@ type NodePoolInitParameters_2 struct {
 
 	// Parameters used in creating the node pool. See
 	// google_container_cluster for schema.
+	// +listType=map
+	// +listMapKey=index
 	NodeConfig []NodePoolNodeConfigInitParameters_2 `json:"nodeConfig,omitempty" tf:"node_config,omitempty"`
 
 	// The number of nodes per instance group. This field can be used to
@@ -486,6 +488,10 @@ type NodePoolNodeConfigInitParameters_2 struct {
 
 	ImageType *string `json:"imageType,omitempty" tf:"image_type,omitempty"`
 
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:="0"
+	Index *string `json:"index,omitempty" tf:"-"`
+
 	KubeletConfig []NodePoolNodeConfigKubeletConfigInitParameters `json:"kubeletConfig,omitempty" tf:"kubelet_config,omitempty"`
 
 	// +mapType=granular
@@ -634,6 +640,10 @@ type NodePoolNodeConfigObservation_2 struct {
 
 	ImageType *string `json:"imageType,omitempty" tf:"image_type,omitempty"`
 
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:="0"
+	Index *string `json:"index,omitempty" tf:"-"`
+
 	KubeletConfig []NodePoolNodeConfigKubeletConfigObservation `json:"kubeletConfig,omitempty" tf:"kubelet_config,omitempty"`
 
 	// +mapType=granular
@@ -714,6 +724,11 @@ type NodePoolNodeConfigParameters_2 struct {
 
 	// +kubebuilder:validation:Optional
 	ImageType *string `json:"imageType,omitempty" tf:"image_type,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:="0"
+	Index *string `json:"index" tf:"-"`
 
 	// +kubebuilder:validation:Optional
 	KubeletConfig []NodePoolNodeConfigKubeletConfigParameters `json:"kubeletConfig,omitempty" tf:"kubelet_config,omitempty"`
@@ -949,6 +964,8 @@ type NodePoolObservation_2 struct {
 
 	// Parameters used in creating the node pool. See
 	// google_container_cluster for schema.
+	// +listType=map
+	// +listMapKey=index
 	NodeConfig []NodePoolNodeConfigObservation_2 `json:"nodeConfig,omitempty" tf:"node_config,omitempty"`
 
 	// The number of nodes per instance group. This field can be used to
@@ -1037,6 +1054,8 @@ type NodePoolParameters_2 struct {
 	// Parameters used in creating the node pool. See
 	// google_container_cluster for schema.
 	// +kubebuilder:validation:Optional
+	// +listType=map
+	// +listMapKey=index
 	NodeConfig []NodePoolNodeConfigParameters_2 `json:"nodeConfig,omitempty" tf:"node_config,omitempty"`
 
 	// The number of nodes per instance group. This field can be used to

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -131,6 +131,18 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Extractor: common.ExtractResourceIDFuncPath,
 		}
 
+		r.ServerSideApplyMergeStrategies["node_config"] = config.MergeStrategy{
+			ListMergeStrategy: config.ListMergeStrategy{
+				MergeStrategy: config.ListTypeMap,
+				ListMapKeys: config.ListMapKeys{
+					InjectedKey: config.InjectedKey{
+						Key:          "index",
+						DefaultValue: `"0"`,
+					},
+				},
+			},
+		}
+
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if diff == nil || diff.Destroy {
 				return diff, nil

--- a/package/crds/container.gcp.upbound.io_nodepools.yaml
+++ b/package/crds/container.gcp.upbound.io_nodepools.yaml
@@ -343,6 +343,11 @@ spec:
                           type: array
                         imageType:
                           type: string
+                        index:
+                          default: "0"
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         kubeletConfig:
                           items:
                             properties:
@@ -553,6 +558,9 @@ spec:
                           type: array
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - index
+                    x-kubernetes-list-type: map
                   nodeCount:
                     description: |-
                       The number of nodes per instance group. This field can be used to
@@ -856,6 +864,11 @@ spec:
                           type: array
                         imageType:
                           type: string
+                        index:
+                          default: "0"
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         kubeletConfig:
                           items:
                             properties:
@@ -1066,6 +1079,9 @@ spec:
                           type: array
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - index
+                    x-kubernetes-list-type: map
                   nodeCount:
                     description: |-
                       The number of nodes per instance group. This field can be used to
@@ -1552,6 +1568,11 @@ spec:
                           type: array
                         imageType:
                           type: string
+                        index:
+                          default: "0"
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         kubeletConfig:
                           items:
                             properties:
@@ -1686,6 +1707,9 @@ spec:
                           type: array
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - index
+                    x-kubernetes-list-type: map
                   nodeCount:
                     description: |-
                       The number of nodes per instance group. This field can be used to


### PR DESCRIPTION
### Description of your changes
The NodePool nodeConfig is a singleton list containing the node config for the pool. By default lists are treated as atomic by server-side-apply, which means only one manager can own them. nodeConfig contains fields resolved by the provider (service account) so if you also try to patch some of the other fields with a composition function then the provider and composition repeatedly delete each others fields.

The ListTypeMap strategy treats the list elements similarly to a granular map, which is what we need, but it requires a key by which to identify each element of the list. There is no such key for nodeConfig, but since it's a singleton we can inject a default using a non-existent name with a fixed value.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Running in kind against GKE, checking audit log to make sure the resource isn't being repeatedly updated.