### PR TITLE
examples: remove namespace from spec.writeConnectionSecretToRef in namespaced MRs

### DIFF
--- a/examples/container/namespaced/v1beta1/registry.yaml
+++ b/examples/container/namespaced/v1beta1/registry.yaml
@@ -16,4 +16,3 @@ spec:
     location: US
   writeConnectionSecretToRef:
     name: example-container-registry-secret
-    namespace: upbound-system

--- a/examples/redis/namespaced/v1beta1/cluster.yaml
+++ b/examples/redis/namespaced/v1beta1/cluster.yaml
@@ -27,8 +27,6 @@ spec:
       mode: MULTI_ZONE
   writeConnectionSecretToRef:
     name: example-redis-cluster-secret
-    namespace: upbound-system
-      
 ---
 apiVersion: compute.gcp.m.upbound.io/v1beta1
 kind: Network

--- a/examples/redis/namespaced/v1beta1/instance.yaml
+++ b/examples/redis/namespaced/v1beta1/instance.yaml
@@ -21,4 +21,3 @@ spec:
     tier: STANDARD_HA
   writeConnectionSecretToRef:
     name: example-redis-instance-secret
-    namespace: upbound-system

--- a/examples/sql/namespaced/v1beta1/instance.yaml
+++ b/examples/sql/namespaced/v1beta1/instance.yaml
@@ -21,4 +21,3 @@ spec:
       tier: db-f1-micro
   writeConnectionSecretToRef:
     name: example-sql-db-instance-secret
-    namespace: upbound-system

--- a/examples/sql/namespaced/v1beta1/sslcert.yaml
+++ b/examples/sql/namespaced/v1beta1/sslcert.yaml
@@ -19,7 +19,6 @@ spec:
         testing.upbound.io/example-name: example_instance
   writeConnectionSecretToRef:
     name: example-sql-ssl-secret
-    namespace: upbound-system
 ---
 apiVersion: sql.gcp.m.upbound.io/v1beta1
 kind: DatabaseInstance

--- a/examples/sql/namespaced/v1beta1/user.yaml
+++ b/examples/sql/namespaced/v1beta1/user.yaml
@@ -21,7 +21,6 @@ spec:
       name: example-sql-user
   writeConnectionSecretToRef:
     name: example-sql-db-user-secret
-    namespace: upbound-system
 ---
 apiVersion: v1
 data:
@@ -55,4 +54,3 @@ spec:
       tier: db-f1-micro
   writeConnectionSecretToRef:
     name: example-sql-db-instance-secret
-    namespace: upbound-system

--- a/examples/storage/namespaced/v1beta1/hmackey.yaml
+++ b/examples/storage/namespaced/v1beta1/hmackey.yaml
@@ -18,7 +18,6 @@ spec:
         testing.upbound.io/example-name: service_account
   writeConnectionSecretToRef:
     name: example-cloud-storage-hmac-secret
-    namespace: upbound-system
 ---
 apiVersion: cloudplatform.gcp.m.upbound.io/v1beta1
 kind: ServiceAccount


### PR DESCRIPTION
### Description of your changes
remove `spec.writeConnectionSecretToRef.namespace` from namespace-scoped examples as it no longer exists in CRDs

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
manually in kind
