### PR TITLE
Use a wildcard for Make variable SUBPACKAGES to represent all family packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,10 @@ BUILDTAGGER_VERSION ?= v0.12.0-rc.0.28.gdc5d6f3
 BUILDTAGGER_DOWNLOAD_URL ?= https://s3.us-west-2.amazonaws.com/upbound.official-providers-ci.releases/main/$(BUILDTAGGER_VERSION)/bin/$(SAFEHOST_PLATFORM)/buildtagger
 endif
 
-# SUBPACKAGES ?= $(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3)
 SUBPACKAGES ?= monolith
+ifeq ($(strip $(SUBPACKAGES)),*)
+override SUBPACKAGES := $(filter-out monolith,$(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3))
+endif
 GO_STATIC_PACKAGES ?= $(GO_PROJECT)/cmd/generator ${SUBPACKAGES:%=$(GO_PROJECT)/cmd/provider/%}
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis generate
@@ -377,7 +379,10 @@ go.lint.analysiskey-interval:
 go.lint.analysiskey:
 	@echo $$(make go.lint.analysiskey-interval)$$(sha1sum go.sum | cut -d' ' -f1)
 
-.PHONY: cobertura reviewable submodules fallthrough go.mod.cachedir go.lint.analysiskey-interval go.lint.analysiskey go.cachedir run crds.clean $(TERRAFORM_PROVIDER_SCHEMA) load-pkg
+print-subpackages:
+	@echo $(SUBPACKAGES)
+
+.PHONY: cobertura reviewable submodules fallthrough go.mod.cachedir go.lint.analysiskey-interval go.lint.analysiskey go.cachedir run crds.clean $(TERRAFORM_PROVIDER_SCHEMA) load-pkg print-subpackages
 
 build.init: kustomize-crds
 


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Relevant PR: https://github.com/crossplane-contrib/provider-upjet-azure/pull/1054

When the make variable "SUBPACKAGES" is set to the literal "*", all family members but the "monolith" are now implied. We can now run a `make SUBPACKAGES='*' ...` to run the target on all family members.

`monolith` is automatically excluded from the list of family members and the config package is included.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manually tested with the `print-subpackages` target:

```shell
> make SUBPACKAGES="*" print-subpackages

dataflow privateca cloudfunctions essentialcontacts orgpolicy datastream servicenetworking binaryauthorization beyondcorp apigee developerconnect kms networkservices vpcaccess containeraws bigtable oslogin gemini gkehub networkmanagement cloudplatform documentai config redis mlengine dataplex activedirectory containerazure cloudfunctions2 healthcare composer appengine filestore datalossprevention datafusion storagetransfer cloudbuild workflows secretmanager accesscontextmanager bigquery sourcerepo storage tags cloudrun container memcache iap vertexai iam gke compute containerattached networkconnectivity eventarc identityplatform cloud containeranalysis cloudtasks cloudquotas pubsub spanner artifact alloydb tpu dialogflowcx networksecurity monitoring cloudscheduler dns notebooks logging datacatalog osconfig certificatemanager firebaserules dataproc sql
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
