### PR TITLE
Use go.mod as single source of truth for Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   detect-noop:
     runs-on: ubuntu-latest
@@ -75,7 +72,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Analysis Cache
         id: analysis_cache
@@ -123,7 +120,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
@@ -176,7 +173,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -206,7 +203,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/uptest-trigger.yml
+++ b/.github/workflows/uptest-trigger.yml
@@ -8,9 +8,6 @@ on:
   issue_comment:
     types: [created]
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   check-permissions:
     runs-on: ubuntu-latest
@@ -21,7 +18,6 @@ jobs:
         id: check-permissions
         run: |
           echo "Trigger keyword: '/test-examples'"
-          echo "Go version: ${{ env.GO_VERSION }}"
 
           REPO=${{ github.repository }}
           COMMENTER=${{ github.event.comment.user.login }}
@@ -115,11 +111,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Checkout PR
         id: checkout-pr
         env:
@@ -129,6 +120,11 @@ jobs:
           git submodule update --init --recursive
           OUTPUT=$(git log -1 --format='%H')
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,119 +2,32 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+version: "2"
+
 run:
   timeout: 90m
 
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  formats:
-    - format: colored-line-number
+  show-stats: true
 
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: false
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: false
-
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    exclude-files:
-      - fmt:.*,io/ioutil:^Read.*
-
-  govet:
-    # report about shadowed variables
-    check-shadowing: false
-
-  revive:
-    # confidence for issues, default is 0.8
-    confidence: 0.8
-
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/upbound/provider-gcp/v2
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 5
-
-  lll:
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  nakedret:
-    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 30
-
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - performance
-
-    settings: # settings passed to gocritic
-      captLocal: # must be valid enabled check name
-        paramsOnly: true
-      rangeValCopy:
-        sizeThreshold: 32
+formatters:
+  enable:
+    - goimports
+    - gofmt
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+      - github.com/upbound/provider-gcp
 
 linters:
+  default: none
   enable:
     - govet
     - gocyclo
     - gocritic
     - goconst
-    - goimports
-    - gofmt  # We enable this as well as goimports for its simplify mode.
-    - gosimple
-    - prealloc
     - revive
     - staticcheck
     - unconvert
@@ -122,80 +35,96 @@ linters:
     - misspell
     - nakedret
 
-  presets:
-    - bugs
-    - unused
-  fast: false
+  settings:
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+      exclude-functions:
+        - io/ioutil.ReadFile
+        - io/ioutil.ReadDir
+        - io/ioutil.ReadAll
 
+    govet:
+      disable:
+        - shadow
+
+    revive:
+      confidence: 0.8
+
+    gocyclo:
+      min-complexity: 10
+
+    dupl:
+      threshold: 100
+
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+
+    lll:
+      tab-width: 1
+
+    unparam:
+      check-exported: false
+
+    nakedret:
+      max-func-lines: 30
+
+    gocritic:
+      enabled-tags:
+        - performance
+      settings:
+        captLocal:
+          paramsOnly: true
+        rangeValCopy:
+          sizeThreshold: 32
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test(ing)?\.go
+        linters:
+          - gocyclo
+          - errcheck
+          - dupl
+          - gosec
+          - unparam
+
+      - path: _test\.go
+        text: "(unnamedResult|exitAfterDefer)"
+        linters:
+          - gocritic
+
+      - text: "(hugeParam|rangeValCopy):"
+        linters:
+          - gocritic
+
+      - text: "SA3000:"
+        linters:
+          - staticcheck
+
+      - text: "QF1008:"
+        linters:
+          - staticcheck
+
+      - text: "k8s.io/api/core/v1"
+        linters:
+          - goimports
+
+      - text: "G101:"
+        linters:
+          - gosec
+
+      - text: "G104:"
+        linters:
+          - gosec
 
 issues:
-  exclude-files:
-    - "zz_\\..+\\.go$"
-  # Excluding configuration per-path and per-linter
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test(ing)?\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-        - scopelint
-        - unparam
-
-    # Ease some gocritic warnings on test files.
-    - path: _test\.go
-      text: "(unnamedResult|exitAfterDefer)"
-      linters:
-        - gocritic
-
-    # These are performance optimisations rather than style issues per se.
-    # They warn when function arguments or range values copy a lot of memory
-    # rather than using a pointer.
-    - text: "(hugeParam|rangeValCopy):"
-      linters:
-      - gocritic
-
-    # This "TestMain should call os.Exit to set exit code" warning is not clever
-    # enough to notice that we call a helper method that calls os.Exit.
-    - text: "SA3000:"
-      linters:
-      - staticcheck
-
-    - text: "k8s.io/api/core/v1"
-      linters:
-      - goimports
-
-    # This is a "potential hardcoded credentials" warning. It's triggered by
-    # any variable with 'secret' in the same, and thus hits a lot of false
-    # positives in Kubernetes land where a Secret is an object type.
-    - text: "G101:"
-      linters:
-      - gosec
-      - gas
-
-    # This is an 'errors unhandled' warning that duplicates errcheck.
-    - text: "G104:"
-      linters:
-      - gosec
-      - gas
-
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing
-  # large codebase. It's not practical to fix all existing issues at the moment
-  # of integration: much better don't allow issues in new code.
-  # Default is false.
   new: false
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-issues-per-linter: 0
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 # correctly.
 export GOPRIVATE = github.com/upbound/*
 
-GO_REQUIRED_VERSION ?= 1.21
+GO_REQUIRED_VERSION ?= $(shell grep -E '^go ' go.mod | awk '{print $2}')
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
-GOLANGCILINT_VERSION ?= 1.64.8
+GOLANGCILINT_VERSION ?= 2.11.3
 
 RUN_BUILDTAGGER ?= false
 # if RUN_BUILDTAGGER is set to "true", we will use build constraints
@@ -409,7 +409,7 @@ build-lint-cache: $(GOLANGCILINT)
 	@# minimum.
 	@(BUILDTAGGER_DOWNLOAD_URL=$(BUILDTAGGER_DOWNLOAD_URL) ./scripts/tag.sh && \
 	(([[ "${SKIP_LINTER_ANALYSIS}" == "true" ]] && $(OK) "Skipping analysis cache build phase because it's already been populated") && \
-	[[ "${SKIP_LINTER_ANALYSIS}" == "true" ]] || $(GOLANGCILINT) run -v --build-tags activedirectory,configregistry,configprovider,linter_run -v --disable-all --exclude '.*')) || $(FAIL)
+	[[ "${SKIP_LINTER_ANALYSIS}" == "true" ]] || $(GOLANGCILINT) run -v --build-tags activedirectory,configregistry,configprovider,linter_run -v --default none)) || $(FAIL)
 	@$(OK) Running golangci-lint with the analysis cache building phase.
 
 delete-build-tags:

--- a/config/cluster/apigee/config.go
+++ b/config/cluster/apigee/config.go
@@ -59,7 +59,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			hasActualDiff := false
 			for _, field := range addonsConfigurationsFields {
 				addonDiff, ok := diff.Attributes[fmt.Sprintf("addons_config.0.%s.0.enabled", field)]
-				if ok && !(addonDiff.Old == "" && addonDiff.New == "false") {
+				if ok && (addonDiff.Old != "" || addonDiff.New != "false") {
 					hasActualDiff = true
 					break
 				}

--- a/config/namespaced/apigee/config.go
+++ b/config/namespaced/apigee/config.go
@@ -59,7 +59,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			hasActualDiff := false
 			for _, field := range addonsConfigurationsFields {
 				addonDiff, ok := diff.Attributes[fmt.Sprintf("addons_config.0.%s.0.enabled", field)]
-				if ok && !(addonDiff.Old == "" && addonDiff.New == "false") {
+				if ok && (addonDiff.Old != "" || addonDiff.New != "false") {
 					hasActualDiff = true
 					break
 				}

--- a/config/registry_cluster.go
+++ b/config/registry_cluster.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/crossplane/upjet/v2/pkg/config/conversion"
 	"github.com/crossplane/upjet/v2/pkg/registry/reference"
@@ -101,8 +100,8 @@ func bumpVersionsWithEmbeddedLists(pc *ujconfig.Provider) {
 			// with the converted API (with embedded objects in place of
 			// singleton lists), so we need the appropriate Terraform
 			// converter in this case.
-			r.TerraformConversions = []config.TerraformConversion{
-				config.NewTFSingletonConversion(),
+			r.TerraformConversions = []ujconfig.TerraformConversion{
+				ujconfig.NewTFSingletonConversion(),
 			}
 		}
 		pc.Resources[n] = r

--- a/config/registry_namespaced.go
+++ b/config/registry_namespaced.go
@@ -7,7 +7,6 @@ package config
 import (
 	"context"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/crossplane/upjet/v2/pkg/registry/reference"
 	"github.com/crossplane/upjet/v2/pkg/schema/traverser"
@@ -81,8 +80,8 @@ func registerTerraformConversions(pc *ujconfig.Provider) {
 		// with the converted API (with embedded objects in place of
 		// singleton lists), so we need the appropriate Terraform
 		// converter in this case.
-		r.TerraformConversions = []config.TerraformConversion{
-			config.NewTFSingletonConversion(),
+		r.TerraformConversions = []ujconfig.TerraformConversion{
+			ujconfig.NewTFSingletonConversion(),
 		}
 		pc.Resources[n] = r
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/upbound/provider-gcp/v2
 
-go 1.24.13
+go 1.25.8
 
 tool golang.org/x/tools/cmd/goimports
 

--- a/internal/clients/gcp.go
+++ b/internal/clients/gcp.go
@@ -116,8 +116,8 @@ func TerraformSetupBuilder(tfProvider *schema.Provider) terraform.SetupFn { //no
 		case xpv1.CredentialsSourceInjectedIdentity:
 			// We don't need to do anything here, as the TF Provider will take care of workloadIdentity etc.
 		case impersonateServiceAccount:
-			if pcSpec.Credentials.ImpersonateServiceAccountSpec.Name != "" {
-				ps.Configuration[keyImpersonateServiceAccount] = pcSpec.Credentials.ImpersonateServiceAccountSpec.Name
+			if pcSpec.Credentials.Name != "" {
+				ps.Configuration[keyImpersonateServiceAccount] = pcSpec.Credentials.Name
 			}
 		case credentialsSourceAccessToken:
 			data, err := resource.CommonCredentialExtractor(ctx, xpv1.CredentialsSourceSecret, crClient, pcSpec.Credentials.CommonCredentialSelectors)

--- a/internal/controller/cluster/providerconfig/config.go
+++ b/internal/controller/cluster/providerconfig/config.go
@@ -39,7 +39,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 // SetupGated adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
 func SetupGated(mgr ctrl.Manager, o controller.Options) error {
-	o.Options.Gate.Register(func() {
+	o.Gate.Register(func() {
 		if err := Setup(mgr, o); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconcilers", "gvk", v1beta1.ProviderConfigGroupVersionKind.String())
 		}

--- a/internal/controller/namespaced/providerconfig/config.go
+++ b/internal/controller/namespaced/providerconfig/config.go
@@ -64,7 +64,7 @@ func setupClusterProviderConfig(mgr ctrl.Manager, o controller.Options) error {
 }
 
 func SetupGated(mgr ctrl.Manager, o controller.Options) error {
-	o.Options.Gate.Register(func() {
+	o.Gate.Register(func() {
 		if err := Setup(mgr, o); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconcilers", "gvk", v1beta1.ClusterProviderConfigGroupVersionKind.String(), "gvk", v1beta1.ProviderConfigGroupVersionKind.String())
 		}


### PR DESCRIPTION
This PR eliminates hardcoded Go version values across the repository by making `go.mod` the single source of truth for the Go version.

- **Workflows**: Updated `ci.yml` and `uptest-trigger.yaml` to use `go-version-file: go.mod` instead of the hardcoded `GO_VERSION` environment variable
- **Makefile**: Changed `GO_REQUIRED_VERSION` to dynamically read from `go.mod` using shell parsing
- **uptest-trigger.yaml**: Moved Setup Go step to after Checkout PR step to ensure `go.mod` is available before reading it

Also bumped go version and linter version.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
