### PR TITLE
fix: ignore 'type' field during late initialization for IAM user support

### DIFF
--- a/config/cluster/sql/config.go
+++ b/config/cluster/sql/config.go
@@ -118,6 +118,13 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			TerraformName: "google_sql_database_instance",
 		}
 
+		// The 'type' field is write-only and not returned by the GCP API.
+		// We need to ignore it during late initialization to prevent it from
+		// being reset to empty (which would create a BUILT_IN user instead of IAM user).
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"type"},
+		}
+
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			if a, ok := attr["password"].(string); ok {

--- a/config/namespaced/sql/config.go
+++ b/config/namespaced/sql/config.go
@@ -118,6 +118,13 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			TerraformName: "google_sql_database_instance",
 		}
 
+		// The 'type' field is write-only and not returned by the GCP API.
+		// We need to ignore it during late initialization to prevent it from
+		// being reset to empty (which would create a BUILT_IN user instead of IAM user).
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"type"},
+		}
+
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			if a, ok := attr["password"].(string); ok {


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

## Reproduction

1. Create a Cloud SQL IAM user with `type: CLOUD_IAM_USER`:
   ```yaml
   apiVersion: sql.gcp.upbound.io/v1beta2
   kind: User
   metadata:
     name: test-iam-user
   spec:
     forProvider:
       instance: my-instance
       name: user@example.com
       type: CLOUD_IAM_USER
   ```

2. Wait for the resource to be created (Ready=True)

3. Check the `type` field in the manifest after a few reconciliation cycles

**Current behavior**: The `type` field becomes empty after reconciliation because the GCP API doesn't return it and LateInitializer resets it. This turns the IAM user into a BUILT_IN user.

**Expected behavior**: The `type` field should persist with the initially specified value `CLOUD_IAM_USER`.

## How to Fix

Adds `LateInitializer.IgnoredFields` for the 'type' field in google_sql_user resource to prevent it from being reset to empty during reconciliation. The 'type' field is write-only and not returned by GCP API, causing IAM users (CLOUD_IAM_USER, CLOUD_IAM_SERVICE_ACCOUNT) to be incorrectly converted to BUILT_IN users.


Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
