### PR TITLE
fix(compute): treat HTTP 400 as not-found for firewall policy and rule resources

### DIFF
--- a/.github/workflows/publish-compute-provider.yaml
+++ b/.github/workflows/publish-compute-provider.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v1.14.0-fix.1)"
+        description: "Version tag (e.g., v2.4.0-fix.1)"
         required: true
 
 permissions:
@@ -41,10 +41,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish compute provider
+      - name: Build compute provider xpkg
         run: |
           make build-provider.compute \
             XPKG_REG_ORGS=${{ env.GHCR_REGISTRY }} \
             VERSION=${{ inputs.version }} \
             PLATFORMS="linux_amd64" \
             BATCH_PLATFORMS="linux_amd64"
+
+      - name: Push compute provider to GHCR
+        run: |
+          VERSION=${{ inputs.version }}
+          XPKG_DIR="_output/package/linux_amd64"
+
+          for xpkg in "${XPKG_DIR}"/*.xpkg; do
+            [ -f "$xpkg" ] || continue
+            loaded=$(docker load -qi "$xpkg")
+            sha="${loaded##*: }"
+            echo "Loaded $xpkg as $sha"
+
+            # Derive image name from xpkg filename:
+            #   provider-gcp-compute-v2.4.0-fix.1.xpkg -> provider-gcp-compute
+            base=$(basename "$xpkg" .xpkg)
+            name="${base%-${VERSION}}"
+
+            target="${{ env.GHCR_REGISTRY }}/${name}:${VERSION}"
+            echo "Tagging and pushing as ${target}"
+            docker tag "$sha" "$target"
+            docker push "$target"
+          done

--- a/.github/workflows/publish-compute-provider.yaml
+++ b/.github/workflows/publish-compute-provider.yaml
@@ -1,0 +1,50 @@
+name: Publish Compute Provider
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v1.14.0-fix.1)"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  GHCR_REGISTRY: ghcr.io/myprizepicks
+
+jobs:
+  publish-compute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          large-packages: false
+          swap-storage: false
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish compute provider
+        run: |
+          make build-provider.compute \
+            XPKG_REG_ORGS=${{ env.GHCR_REGISTRY }} \
+            VERSION=${{ inputs.version }} \
+            PLATFORMS="linux_amd64" \
+            BATCH_PLATFORMS="linux_amd64"

--- a/.github/workflows/publish-compute-provider.yaml
+++ b/.github/workflows/publish-compute-provider.yaml
@@ -52,21 +52,22 @@ jobs:
       - name: Push compute provider to GHCR
         run: |
           VERSION=${{ inputs.version }}
-          XPKG_DIR="_output/package/linux_amd64"
 
-          for xpkg in "${XPKG_DIR}"/*.xpkg; do
-            [ -f "$xpkg" ] || continue
-            loaded=$(docker load -qi "$xpkg")
-            sha="${loaded##*: }"
-            echo "Loaded $xpkg as $sha"
+          echo "=== Docker images after build ==="
+          docker images | grep provider-gcp || true
 
-            # Derive image name from xpkg filename:
-            #   provider-gcp-compute-v2.4.0-fix.1.xpkg -> provider-gcp-compute
-            base=$(basename "$xpkg" .xpkg)
-            name="${base%-${VERSION}}"
+          # The build-provider target loads xpkg into Docker with a
+          # build-registry prefix (e.g. build-<hash>/provider-gcp-compute-amd64).
+          # Find it, retag for GHCR, and push.
+          COMPUTE_IMG=$(docker images --format "{{.Repository}}" | grep "provider-gcp-compute" | head -1)
+          if [ -z "$COMPUTE_IMG" ]; then
+            echo "ERROR: No provider-gcp-compute image found in Docker"
+            docker images
+            exit 1
+          fi
 
-            target="${{ env.GHCR_REGISTRY }}/${name}:${VERSION}"
-            echo "Tagging and pushing as ${target}"
-            docker tag "$sha" "$target"
-            docker push "$target"
-          done
+          TARGET="${{ env.GHCR_REGISTRY }}/provider-gcp-compute:${VERSION}"
+          echo "Retagging ${COMPUTE_IMG} -> ${TARGET}"
+          docker tag "${COMPUTE_IMG}" "${TARGET}"
+          docker push "${TARGET}"
+          echo "Pushed ${TARGET}"

--- a/config/cluster/compute/config.go
+++ b/config/cluster/compute/config.go
@@ -5,12 +5,15 @@
 package compute
 
 import (
+	"log"
+
 	"github.com/crossplane/crossplane-runtime/v2/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reference"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/upbound/provider-gcp/v2/config/cluster/common"
 )
@@ -519,6 +522,52 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	p.AddResourceConfigurator("google_compute_region_security_policy", func(r *config.Resource) {
 		r.MarkAsRequired("region")
 	})
+
+	// The GCP Compute API's getAssociation endpoint returns HTTP 400 instead
+	// of 404 when a firewall policy association does not exist. The Terraform
+	// provider's HandleNotFoundError only recognizes 404 as "not found", so
+	// upjet treats the 400 as a reconciliation error and never proceeds to
+	// Create. We wrap the Read function to also treat 400 as "not found".
+	for _, resource := range []string{
+		"google_compute_firewall_policy_association",
+		"google_compute_network_firewall_policy_association",
+		"google_compute_region_network_firewall_policy_association",
+	} {
+		p.AddResourceConfigurator(resource, func(r *config.Resource) {
+			originalRead := r.TerraformResource.Read
+			r.TerraformResource.Read = func(d *schema.ResourceData, meta any) error {
+				err := originalRead(d, meta)
+				if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 400) {
+					log.Printf("[WARN] Removing %s %q because GCP returned 400 (treating as not found)", resource, d.Id())
+					d.SetId("")
+					return nil
+				}
+				return err
+			}
+		})
+	}
+
+	// The GCP Compute API's getRule endpoint uses the same RPC-style URL
+	// pattern and returns HTTP 400 instead of 404 when a firewall policy
+	// rule or security policy rule does not exist.
+	for _, resource := range []string{
+		"google_compute_firewall_policy_rule",
+		"google_compute_network_firewall_policy_rule",
+		"google_compute_region_network_firewall_policy_rule",
+	} {
+		p.AddResourceConfigurator(resource, func(r *config.Resource) {
+			originalRead := r.TerraformResource.Read
+			r.TerraformResource.Read = func(d *schema.ResourceData, meta any) error {
+				err := originalRead(d, meta)
+				if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 400) {
+					log.Printf("[WARN] Removing %s %q because GCP returned 400 (treating as not found)", resource, d.Id())
+					d.SetId("")
+					return nil
+				}
+				return err
+			}
+		})
+	}
 }
 
 // InstanceGroupExtractor extracts Instance Group from

--- a/config/namespaced/compute/config.go
+++ b/config/namespaced/compute/config.go
@@ -5,12 +5,15 @@
 package compute
 
 import (
+	"log"
+
 	"github.com/crossplane/crossplane-runtime/v2/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reference"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/upbound/provider-gcp/v2/config/namespaced/common"
 )
@@ -519,6 +522,52 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	p.AddResourceConfigurator("google_compute_region_security_policy", func(r *config.Resource) {
 		r.MarkAsRequired("region")
 	})
+
+	// The GCP Compute API's getAssociation endpoint returns HTTP 400 instead
+	// of 404 when a firewall policy association does not exist. The Terraform
+	// provider's HandleNotFoundError only recognizes 404 as "not found", so
+	// upjet treats the 400 as a reconciliation error and never proceeds to
+	// Create. We wrap the Read function to also treat 400 as "not found".
+	for _, resource := range []string{
+		"google_compute_firewall_policy_association",
+		"google_compute_network_firewall_policy_association",
+		"google_compute_region_network_firewall_policy_association",
+	} {
+		p.AddResourceConfigurator(resource, func(r *config.Resource) {
+			originalRead := r.TerraformResource.Read
+			r.TerraformResource.Read = func(d *schema.ResourceData, meta any) error {
+				err := originalRead(d, meta)
+				if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 400) {
+					log.Printf("[WARN] Removing %s %q because GCP returned 400 (treating as not found)", resource, d.Id())
+					d.SetId("")
+					return nil
+				}
+				return err
+			}
+		})
+	}
+
+	// The GCP Compute API's getRule endpoint uses the same RPC-style URL
+	// pattern and returns HTTP 400 instead of 404 when a firewall policy
+	// rule or security policy rule does not exist.
+	for _, resource := range []string{
+		"google_compute_firewall_policy_rule",
+		"google_compute_network_firewall_policy_rule",
+		"google_compute_region_network_firewall_policy_rule",
+	} {
+		p.AddResourceConfigurator(resource, func(r *config.Resource) {
+			originalRead := r.TerraformResource.Read
+			r.TerraformResource.Read = func(d *schema.ResourceData, meta any) error {
+				err := originalRead(d, meta)
+				if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 400) {
+					log.Printf("[WARN] Removing %s %q because GCP returned 400 (treating as not found)", resource, d.Id())
+					d.SetId("")
+					return nil
+				}
+				return err
+			}
+		})
+	}
 }
 
 // InstanceGroupExtractor extracts Instance Group from


### PR DESCRIPTION
## Summary

The GCP Compute API uses RPC-style endpoints (`getAssociation`, `getRule`) for firewall policy sub-resources. These endpoints return HTTP 400 instead of 404 when a sub-resource does not exist. The Terraform provider's `HandleNotFoundError` only recognizes 404, so upjet treats 400 as a reconciliation error and never proceeds to resource creation.

This extends the fix from commit `174643ef0` (which addressed network firewall policy associations) to all affected Compute resources that use these same RPC-style endpoints.

## Changes

- Wrap the `Read` function for firewall policy **association** resources to intercept HTTP 400 and treat as not-found:
  - `google_compute_firewall_policy_association` (org-level — newly covered)
  - `google_compute_network_firewall_policy_association` (global — was fixed in prior commit)
  - `google_compute_region_network_firewall_policy_association` (regional — was fixed in prior commit)
- Wrap the `Read` function for firewall policy **rule** resources that use the `getRule` endpoint (same API pattern):
  - `google_compute_firewall_policy_rule`
  - `google_compute_network_firewall_policy_rule`
  - `google_compute_region_network_firewall_policy_rule`
- Applied to both `config/cluster/` and `config/namespaced/` compute configs

## Test plan

- [ ] Deploy the compute provider with these changes
- [ ] Create and delete firewall policy associations — verify no 400 reconciliation errors
- [ ] Create and delete firewall policy rules — verify no 400 reconciliation errors
- [ ] Verify existing firewall policy resources continue to reconcile normally

## Linear

Resolves SRE-1048