### PR TITLE
Update validatefunc and diffsuppress for container.Cluster resource

### DIFF
--- a/apis/cluster/container/v1beta2/zz_cluster_types.go
+++ b/apis/cluster/container/v1beta2/zz_cluster_types.go
@@ -2349,7 +2349,6 @@ type DatabaseEncryptionInitParameters struct {
 	// the key to use to encrypt/decrypt secrets.  See the DatabaseEncryption definition for more information.
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
-	// ENCRYPTED or DECRYPTED
 	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
@@ -2359,7 +2358,6 @@ type DatabaseEncryptionObservation struct {
 	// the key to use to encrypt/decrypt secrets.  See the DatabaseEncryption definition for more information.
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
-	// ENCRYPTED or DECRYPTED
 	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
@@ -2370,7 +2368,6 @@ type DatabaseEncryptionParameters struct {
 	// +kubebuilder:validation:Optional
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
-	// ENCRYPTED or DECRYPTED
 	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	// +kubebuilder:validation:Optional
 	State *string `json:"state" tf:"state,omitempty"`

--- a/apis/cluster/container/v1beta2/zz_cluster_types.go
+++ b/apis/cluster/container/v1beta2/zz_cluster_types.go
@@ -2350,6 +2350,7 @@ type DatabaseEncryptionInitParameters struct {
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
 	// ENCRYPTED or DECRYPTED
+	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
 
@@ -2359,6 +2360,7 @@ type DatabaseEncryptionObservation struct {
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
 	// ENCRYPTED or DECRYPTED
+	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
 
@@ -2369,6 +2371,7 @@ type DatabaseEncryptionParameters struct {
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
 	// ENCRYPTED or DECRYPTED
+	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	// +kubebuilder:validation:Optional
 	State *string `json:"state" tf:"state,omitempty"`
 }

--- a/apis/namespaced/container/v1beta1/zz_cluster_types.go
+++ b/apis/namespaced/container/v1beta1/zz_cluster_types.go
@@ -2351,6 +2351,7 @@ type DatabaseEncryptionInitParameters struct {
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
 	// ENCRYPTED or DECRYPTED
+	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
 
@@ -2360,6 +2361,7 @@ type DatabaseEncryptionObservation struct {
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
 	// ENCRYPTED or DECRYPTED
+	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
 
@@ -2370,6 +2372,7 @@ type DatabaseEncryptionParameters struct {
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
 	// ENCRYPTED or DECRYPTED
+	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	// +kubebuilder:validation:Optional
 	State *string `json:"state" tf:"state,omitempty"`
 }

--- a/apis/namespaced/container/v1beta1/zz_cluster_types.go
+++ b/apis/namespaced/container/v1beta1/zz_cluster_types.go
@@ -2350,7 +2350,6 @@ type DatabaseEncryptionInitParameters struct {
 	// the key to use to encrypt/decrypt secrets.  See the DatabaseEncryption definition for more information.
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
-	// ENCRYPTED or DECRYPTED
 	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
@@ -2360,7 +2359,6 @@ type DatabaseEncryptionObservation struct {
 	// the key to use to encrypt/decrypt secrets.  See the DatabaseEncryption definition for more information.
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
-	// ENCRYPTED or DECRYPTED
 	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 }
@@ -2371,7 +2369,6 @@ type DatabaseEncryptionParameters struct {
 	// +kubebuilder:validation:Optional
 	KeyName *string `json:"keyName,omitempty" tf:"key_name,omitempty"`
 
-	// ENCRYPTED or DECRYPTED
 	// ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
 	// +kubebuilder:validation:Optional
 	State *string `json:"state" tf:"state,omitempty"`

--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -140,6 +140,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
 			Schema["state"].ValidateFunc = validation.StringInSlice([]string{"ENCRYPTED", "ALL_OBJECTS_ENCRYPTION_ENABLED", "DECRYPTED"}, false)
+		r.MetaResource.ArgumentDocs["database_encryption.state"] = ""
 		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
 			Schema["state"].Description = `ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.`
 		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).

--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"net/url"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
@@ -135,6 +137,13 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 
 		r.MarkAsRequired("location")
+
+		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
+			Schema["state"].ValidateFunc = validation.StringInSlice([]string{"ENCRYPTED", "ALL_OBJECTS_ENCRYPTION_ENABLED", "DECRYPTED"}, false)
+		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
+			Schema["state"].Description = `ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.`
+		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
+			Schema["state"].DiffSuppressFunc = DatabaseEncryptionSuppress
 	})
 
 	p.AddResourceConfigurator("google_container_node_pool", func(r *config.Resource) {
@@ -173,4 +182,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			return diff, nil
 		}
 	})
+}
+
+func DatabaseEncryptionSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// The API sometimes returns ALL_OBJECTS_ENCRYPTION_ENABLED when the user sets ENCRYPTED
+	// and vice versa (depending on the cluster version and underlying resource storage).
+	if old == "ALL_OBJECTS_ENCRYPTION_ENABLED" && new == "ENCRYPTED" {
+		return true
+	}
+	if old == "ENCRYPTED" && new == "ALL_OBJECTS_ENCRYPTION_ENABLED" {
+		return true
+	}
+	return false
 }

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -140,6 +140,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
 			Schema["state"].ValidateFunc = validation.StringInSlice([]string{"ENCRYPTED", "ALL_OBJECTS_ENCRYPTION_ENABLED", "DECRYPTED"}, false)
+		r.MetaResource.ArgumentDocs["database_encryption.state"] = ""
 		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
 			Schema["state"].Description = `ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.`
 		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"net/url"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
@@ -135,6 +137,13 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 
 		r.MarkAsRequired("location")
+
+		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
+			Schema["state"].ValidateFunc = validation.StringInSlice([]string{"ENCRYPTED", "ALL_OBJECTS_ENCRYPTION_ENABLED", "DECRYPTED"}, false)
+		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
+			Schema["state"].Description = `ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.`
+		r.TerraformResource.Schema["database_encryption"].Elem.(*schema.Resource).
+			Schema["state"].DiffSuppressFunc = DatabaseEncryptionSuppress
 	})
 
 	p.AddResourceConfigurator("google_container_node_pool", func(r *config.Resource) {
@@ -173,4 +182,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			return diff, nil
 		}
 	})
+}
+
+func DatabaseEncryptionSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// The API sometimes returns ALL_OBJECTS_ENCRYPTION_ENABLED when the user sets ENCRYPTED
+	// and vice versa (depending on the cluster version and underlying resource storage).
+	if old == "ALL_OBJECTS_ENCRYPTION_ENABLED" && new == "ENCRYPTED" {
+		return true
+	}
+	if old == "ENCRYPTED" && new == "ALL_OBJECTS_ENCRYPTION_ENABLED" {
+		return true
+	}
+	return false
 }

--- a/package/crds/container.gcp.m.upbound.io_clusters.yaml
+++ b/package/crds/container.gcp.m.upbound.io_clusters.yaml
@@ -548,7 +548,9 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: ENCRYPTED or DECRYPTED
+                        description: |-
+                          ENCRYPTED or DECRYPTED
+                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -2856,7 +2858,9 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: ENCRYPTED or DECRYPTED
+                        description: |-
+                          ENCRYPTED or DECRYPTED
+                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -5215,7 +5219,9 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: ENCRYPTED or DECRYPTED
+                        description: |-
+                          ENCRYPTED or DECRYPTED
+                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:

--- a/package/crds/container.gcp.m.upbound.io_clusters.yaml
+++ b/package/crds/container.gcp.m.upbound.io_clusters.yaml
@@ -548,9 +548,8 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: |-
-                          ENCRYPTED or DECRYPTED
-                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
+                        description: ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or
+                          DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -2858,9 +2857,8 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: |-
-                          ENCRYPTED or DECRYPTED
-                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
+                        description: ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or
+                          DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -5219,9 +5217,8 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: |-
-                          ENCRYPTED or DECRYPTED
-                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
+                        description: ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or
+                          DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:

--- a/package/crds/container.gcp.upbound.io_clusters.yaml
+++ b/package/crds/container.gcp.upbound.io_clusters.yaml
@@ -8963,7 +8963,9 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: ENCRYPTED or DECRYPTED
+                        description: |-
+                          ENCRYPTED or DECRYPTED
+                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -11247,7 +11249,9 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: ENCRYPTED or DECRYPTED
+                        description: |-
+                          ENCRYPTED or DECRYPTED
+                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -13610,7 +13614,9 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: ENCRYPTED or DECRYPTED
+                        description: |-
+                          ENCRYPTED or DECRYPTED
+                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:

--- a/package/crds/container.gcp.upbound.io_clusters.yaml
+++ b/package/crds/container.gcp.upbound.io_clusters.yaml
@@ -8963,9 +8963,8 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: |-
-                          ENCRYPTED or DECRYPTED
-                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
+                        description: ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or
+                          DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -11249,9 +11248,8 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: |-
-                          ENCRYPTED or DECRYPTED
-                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
+                        description: ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or
+                          DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:
@@ -13614,9 +13612,8 @@ spec:
                           the DatabaseEncryption definition for more information.
                         type: string
                       state:
-                        description: |-
-                          ENCRYPTED or DECRYPTED
-                          ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.
+                        description: ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or
+                          DECRYPTED.
                         type: string
                     type: object
                   datapathProvider:


### PR DESCRIPTION
### Description of your changes

The problem is that when the databaseEncryption.state is set to `ENABLED`, an update loop occurs because the Google SDK sets the value to `ALL_OBJECTS_ENCRYPTION_ENABLED`. Here is the referenced issue in the upstream repo: https://github.com/hashicorp/terraform-provider-google/issues/26882. The fix is just available for v7 versions. Still, we are on v6, and we copied the solution as a configuration.

This PR adds `ValidateFunc` and `DiffSuppress` functions configurations for the `container.Cluster` resource to address the issue about the `databaseEncryption.state` parameter.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested locally.

[contribution process]: https://git.io/fj2m9
