### PR TITLE
testing: add API conversion roundtrip tests

### DIFF
--- a/apis/cluster/compute/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/compute/v1beta1/zz_generated.deepcopy.go
@@ -45317,13 +45317,9 @@ func (in *PathMatcherDefaultRouteActionObservation) DeepCopyInto(out *PathMatche
 	}
 	if in.RetryPolicy != nil {
 		in, out := &in.RetryPolicy, &out.RetryPolicy
-		*out = new([]DefaultRouteActionRetryPolicyObservation)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]DefaultRouteActionRetryPolicyObservation, len(*in))
-			for i := range *in {
-				(*in)[i].DeepCopyInto(&(*out)[i])
-			}
+		*out = make([]DefaultRouteActionRetryPolicyObservation, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Timeout != nil {

--- a/apis/cluster/compute/v1beta1/zz_regionurlmap_types.go
+++ b/apis/cluster/compute/v1beta1/zz_regionurlmap_types.go
@@ -1879,7 +1879,7 @@ type PathMatcherDefaultRouteActionObservation struct {
 
 	// Specifies the retry policy associated with this route.
 	// Structure is documented below.
-	RetryPolicy *[]DefaultRouteActionRetryPolicyObservation `json:"retryPolicy,omitempty" tf:"retry_policy,omitempty"`
+	RetryPolicy []DefaultRouteActionRetryPolicyObservation `json:"retryPolicy,omitempty" tf:"retry_policy,omitempty"`
 
 	// Specifies the timeout for the selected route. Timeout is computed from the time
 	// the request is has been fully processed (i.e. end-of-stream) up until the

--- a/config/test/roundtrip/roundtrip_test.go
+++ b/config/test/roundtrip/roundtrip_test.go
@@ -1,0 +1,70 @@
+package roundtrip
+
+//nolint:typecheck // due to buildtagger constraints
+
+import (
+	"testing"
+
+	"github.com/crossplane/upjet/v2/pkg/apitesting/roundtrip"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-provider-google/google/provider"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clusterapis "github.com/upbound/provider-gcp/v2/apis/cluster"
+	containerv1beta1 "github.com/upbound/provider-gcp/v2/apis/cluster/container/v1beta1"
+	namespacedapis "github.com/upbound/provider-gcp/v2/apis/namespaced"
+	"github.com/upbound/provider-gcp/v2/config"
+)
+
+func TestRoundTrip(t *testing.T) {
+
+	schema := provider.Provider()
+	ujProviderCluster, err := config.GetProvider(t.Context(), schema, false)
+	if err != nil {
+		t.Fatalf("GetProvider: %s", err)
+	}
+
+	ujProviderNamespaced, err := config.GetNamespacedProvider(t.Context(), schema, false)
+	if err != nil {
+		t.Fatalf("GetNamespacedProvider: %s", err)
+	}
+
+	testScheme := runtime.NewScheme()
+
+	if err := clusterapis.AddToScheme(testScheme); err != nil {
+		t.Fatalf("cluster-scoped apis AddToScheme: %s", err)
+	}
+
+	if err := namespacedapis.AddToScheme(testScheme); err != nil {
+		t.Fatalf("namespaced apis AddToScheme: %s", err)
+	}
+
+	rt, err := roundtrip.NewRoundTripTest(ujProviderCluster, ujProviderNamespaced, testScheme,
+		roundtrip.WithFuzzerConfig(
+			roundtrip.FuzzerIterations(10),
+			roundtrip.FuzzerNilChance(0)),
+		roundtrip.WithFuzzerConfig(
+			roundtrip.FuzzerIterations(30),
+			roundtrip.FuzzerNilChance(0.3)),
+		roundtrip.WithComparisonOptions(
+			roundtrip.EquateEmptyAndSingleZeroSlice(),
+			roundtrip.EquateNilAndZeroValuePtr(),
+			// ignore manually-injected SSA index fields at comparison
+			cmpopts.IgnoreFields(containerv1beta1.NodePoolNodeConfigInitParameters_2{}, "Index"),
+			cmpopts.IgnoreFields(containerv1beta1.NodePoolNodeConfigParameters_2{}, "Index"),
+			cmpopts.IgnoreFields(containerv1beta1.NodePoolNodeConfigObservation_2{}, "Index"),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewRoundTripTest: %s", err)
+	}
+
+	t.Run("TestSerializationRoundtrip", func(t *testing.T) {
+		rt.TestSerializationRoundtrip(t)
+	})
+
+	t.Run("TestConversionRoundtrip", func(t *testing.T) {
+		rt.TestConversionRoundtrip(t)
+	})
+
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.2.1
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.2.1-0.20260517113542-0beea8e928de
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20250805162037-2fd0afa09363
@@ -91,7 +92,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -48,6 +48,7 @@ fi
 # config/provider.go -> configprovider || register || config || all
 "${TAGGER}" --parent-dir "${REPO_ROOT}"/config/cluster/provider.go --tag-format "(configprovider || all) && !linter_run" --mode file ${EXTRA_BUILDTAGGER_ARGS}
 "${TAGGER}" --parent-dir "${REPO_ROOT}"/config/namespaced/provider.go --tag-format "(configprovider || all) && !linter_run" --mode file ${EXTRA_BUILDTAGGER_ARGS}
+"${TAGGER}" --parent-dir "${REPO_ROOT}"/config/test/roundtrip/roundtrip_test.go --tag-format "(configprovider || all) && !linter_run" --mode file ${EXTRA_BUILDTAGGER_ARGS}
 
 # config/overrides.go -> configprovider || register || config || all
 "${TAGGER}" --parent-dir "${REPO_ROOT}"/config/overrides.go --tag-format "configprovider || all" --mode file ${EXTRA_BUILDTAGGER_ARGS}


### PR DESCRIPTION
### Description of your changes

Adds API (conversion & serialization) roundtrip tests for multiversion MR APIs.
Integrates API roundtrip testing library at https://github.com/crossplane/upjet/pull/636, see the PR description for details on how it works.

The aim is to verify after conversions or serializations, the original resource is intact with no missing data 

First, prepares a `RoundtripTest` instance by supplying a test scheme with all APIs registered and configuring fuzzers
#### Serialization roundtrip:
For each API in the scheme, create a runtime instance by fuzzing API values, according to the given fuzzer
Then serialize and deserialize, compare the original vs roundtripped are equal

#### Conversion roundtrip:
- test library discovers all APIs that has multiple versions
- for each multi-version API, classifies hub and spoke versions
- Then, for each hub-spoke  pair, runs the following
  - start with hub, convert to spoke, convert back to hub, compare original vs roundtripped hub
  - start with spoke, convert to hub, convert back to spoke, compare original vs roundtripped spoke

#### Example:
`FooResource` API has 3 versions: `v1beta1`, `v1beta2`, `v1beta3` and `v1beta1` is the hub version, others being spoke. Following tests will run:

for v1beta1 - v1beta2 pair:
- `Hub v1beta1 -> Spoke v1beta2 -> Hub v1beta1`
- `Spoke v1beta2 -> Hub v1beta1 -> Spoke v1beta2`

for v1beta1-v1beta3 pair
- `Hub v1beta1 -> Spoke v1beta3 -> Hub v1beta1`
- `Spoke v1beta3 -> Hub v1beta1 -> Spoke v1beta2`


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`make test` and CI

[contribution process]: https://git.io/fj2m9
