### PR TITLE
Implement `upjet_resource_external_api_calls_total` metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,13 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
 	github.com/crossplane/upjet/v2 v2.3.1-0.20260727065433-d310c02d38ab
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20260630172028-e40b75688dfe
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/grpc v1.82.1
 	k8s.io/api v0.35.3
 	k8s.io/apiextensions-apiserver v0.35.0
@@ -92,7 +94,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -144,7 +145,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/clients/gcp.go
+++ b/internal/clients/gcp.go
@@ -8,15 +8,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/apis/configuration/v1alpha1"
+	upjetmetrics "github.com/crossplane/upjet/v2/pkg/metrics"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tfsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	transporttpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,6 +86,39 @@ func constructFederatedCredentials(providerID, serviceAccount string) ([]byte, e
 			File: upboundProviderIdentityTokenFile,
 		},
 	})
+}
+
+// metricsRoundTripper increments the upjet ExternalAPICalls metric for every
+// Google API response it observes. It sits at the outermost layer of the GCP
+// provider's transport chain, so it counts logical API calls rather than
+// individual retry attempts.
+type metricsRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (m *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := m.base.RoundTrip(req)
+	if err == nil && resp != nil {
+		upjetmetrics.ExternalAPICalls.WithLabelValues(serviceFromURL(req.URL), req.Method).Inc()
+	}
+	return resp, err
+}
+
+// serviceFromURL extracts a short service label from a Google API request URL.
+//
+// GCP URL patterns:
+//   - compute.googleapis.com/compute/v1/...  → "compute"
+//   - storage.googleapis.com/...             → "storage"
+//   - www.googleapis.com/storage/v1/...      → "storage" (generic host → path fallback)
+func serviceFromURL(u *url.URL) string {
+	host := u.Hostname()
+	if label, _, _ := strings.Cut(host, "."); label != "" && label != "www" {
+		return label
+	}
+	if seg, _, _ := strings.Cut(strings.TrimPrefix(u.Path, "/"), "/"); seg != "" {
+		return seg
+	}
+	return "unknown"
 }
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
@@ -175,6 +213,13 @@ func configureNoForkGCPClient(ps *terraform.Setup, p schema.Provider) error {
 		return errors.Errorf("failed to configure the provider: %v", diag)
 	}
 	ps.Meta = p.Meta()
+	if config, ok := ps.Meta.(*transporttpg.Config); ok && config.Client != nil {
+		base := config.Client.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		config.Client.Transport = &metricsRoundTripper{base: base}
+	}
 	return nil
 }
 

--- a/internal/clients/gcp_test.go
+++ b/internal/clients/gcp_test.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	upjetmetrics "github.com/crossplane/upjet/v2/pkg/metrics"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func Test_serviceFromURL(t *testing.T) {
+	type args struct {
+		rawURL string
+	}
+	type want struct {
+		service string
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"service_in_host": {
+			args: args{rawURL: "https://compute.googleapis.com/compute/v1/projects/p/zones/z/instances"},
+			want: want{service: "compute"},
+		},
+		"generic_host_path_fallback": {
+			args: args{rawURL: "https://www.googleapis.com/storage/v1/b/bucket"},
+			want: want{service: "storage"},
+		},
+		"host_with_port": {
+			args: args{rawURL: "https://compute.googleapis.com:443/compute/v1/projects/p"},
+			want: want{service: "compute"},
+		},
+		"generic_host_no_path": {
+			args: args{rawURL: "https://www.googleapis.com"},
+			want: want{service: "unknown"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(tc.args.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse(%q): %v", tc.args.rawURL, err)
+			}
+			got := serviceFromURL(u)
+			if diff := cmp.Diff(tc.want.service, got); diff != "" {
+				t.Errorf("serviceFromURL(%q) mismatch (-want +got):\n%s", tc.args.rawURL, diff)
+			}
+		})
+	}
+}
+
+func Test_metricsRoundTripper(t *testing.T) {
+	errBoom := errors.New("boom")
+	type args struct {
+		rawURL  string
+		method  string
+		baseErr error
+	}
+	type want struct {
+		inc float64
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"counts_successful_call": {
+			args: args{rawURL: "https://compute.googleapis.com/compute/v1/projects/p", method: http.MethodGet},
+			want: want{inc: 1},
+		},
+		"does_not_count_transport_error": {
+			args: args{rawURL: "https://dns.googleapis.com/dns/v1/projects/p", method: http.MethodPost, baseErr: errBoom},
+			want: want{inc: 0},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(tc.args.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse(%q): %v", tc.args.rawURL, err)
+			}
+			counter := upjetmetrics.ExternalAPICalls.WithLabelValues(serviceFromURL(u), tc.args.method)
+			before := testutil.ToFloat64(counter)
+
+			var wantResp *http.Response
+			if tc.args.baseErr == nil {
+				wantResp = &http.Response{StatusCode: http.StatusOK}
+			}
+			base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return wantResp, tc.args.baseErr
+			})
+			rt := &metricsRoundTripper{base: base}
+
+			resp, err := rt.RoundTrip(&http.Request{Method: tc.args.method, URL: u})
+			if !errors.Is(err, tc.args.baseErr) {
+				t.Fatalf("RoundTrip err = %v, want %v", err, tc.args.baseErr)
+			}
+			if resp != wantResp {
+				t.Errorf("RoundTrip response not passed through unchanged")
+			}
+			if diff := cmp.Diff(tc.want.inc, testutil.ToFloat64(counter)-before); diff != "" {
+				t.Errorf("counter delta mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes
Implements `upjet_resource_external_api_calls_total` metrics by round tripping the gcp http client

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested locally using the following resources:
```yaml
apiVersion: v1
items:
- apiVersion: cloudplatform.gcp.m.upbound.io/v1beta1
  kind: ServiceAccount
  metadata:
    annotations:
      crossplane.io/external-create-pending: "2026-06-30T07:11:00Z"
      crossplane.io/external-create-succeeded: "2026-06-30T07:11:00Z"
      crossplane.io/external-name: example-service-account
      meta.upbound.io/example-id: cloudplatform/v1beta1/serviceaccount
    creationTimestamp: "2026-06-30T07:10:58Z"
    finalizers:
    - finalizer.managedresource.crossplane.io
    generation: 3
    labels:
      testing.upbound.io/example-name: example_service_account
    name: example-service-account
    namespace: upbound-system
    resourceVersion: "12841"
    uid: 47501833-a2a3-47b4-9b16-26547c85c17d
  spec:
    forProvider:
      displayName: Upbound Example Service Account
      project: official-provider-testing
    initProvider: {}
    managementPolicies:
    - '*'
    providerConfigRef:
      kind: ClusterProviderConfig
      name: default
  status:
    atProvider:
      description: ""
      disabled: false
      displayName: Upbound Example Service Account
      email: example-service-account@official-provider-testing.iam.gserviceaccount.com
      id: projects/official-provider-testing/serviceAccounts/example-service-account@official-provider-testing.iam.gserviceaccount.com
      member: serviceAccount:example-service-account@official-provider-testing.iam.gserviceaccount.com
      name: projects/official-provider-testing/serviceAccounts/example-service-account@official-provider-testing.iam.gserviceaccount.com
      project: official-provider-testing
      uniqueId: "109806159240467196851"
    conditions:
    - lastTransitionTime: "2026-06-30T07:11:17Z"
      reason: Available
      status: "True"
      type: Ready
    - lastTransitionTime: "2026-06-30T07:11:16Z"
      observedGeneration: 3
      reason: ReconcileSuccess
      status: "True"
      type: Synced
    - lastTransitionTime: "2026-06-30T07:11:15Z"
      reason: Success
      status: "True"
      type: LastAsyncOperation
- apiVersion: compute.gcp.m.upbound.io/v1beta1
  kind: Image
  metadata:
    annotations:
      crossplane.io/external-create-failed: "2026-06-30T07:11:43Z"
      crossplane.io/external-create-pending: "2026-06-30T07:11:43Z"
      crossplane.io/external-create-succeeded: "2026-06-30T07:10:59Z"
      crossplane.io/external-name: image
      meta.upbound.io/example-id: compute/v1beta1/image
    creationTimestamp: "2026-06-30T07:10:58Z"
    finalizers:
    - finalizer.managedresource.crossplane.io
    generation: 2
    labels:
      testing.upbound.io/example-name: image
    name: image
    namespace: upbound-system
    resourceVersion: "12904"
    uid: e7948bfd-4089-4bf3-a8dd-5b8d9e2f6721
  spec:
    forProvider:
      rawDisk:
        source: https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz
    initProvider: {}
    managementPolicies:
    - '*'
    providerConfigRef:
      kind: ClusterProviderConfig
      name: default
  status:
    atProvider: {}
    conditions:
    - lastTransitionTime: "2026-06-30T07:10:59Z"
      observedGeneration: 2
      reason: Creating
      status: "False"
      type: Ready
    - lastTransitionTime: "2026-06-30T07:11:42Z"
      message: |-
        create failed: async create failed: failed to create the resource: [{0 Error waiting to create Image: Error waiting for Creating Image: Required 'read' permission for 'bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz'
          []}]
      reason: ReconcileError
      status: "False"
      type: Synced
    - lastTransitionTime: "2026-06-30T07:11:42Z"
      message: |-
        async create failed: failed to create the resource: [{0 Error waiting to create Image: Error waiting for Creating Image: Required 'read' permission for 'bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz'
          []}]
      reason: AsyncCreateFailure
      status: "False"
      type: LastAsyncOperation
kind: List
```
Results:
```shell
judasz@Jonaszs-MacBook-Pro provider-upjet-gcp % curl localhost:8080/metrics | rg "upjet_resource_external_api_calls_total"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP upjet_resource_external_api_calls_total The number of external API calls.
# TYPE upjet_resource_external_api_calls_total counter
upjet_resource_external_api_calls_total{operation="DELETE",service="iam"} 1
upjet_resource_external_api_calls_total{operation="GET",service="compute"} 13
upjet_resource_external_api_calls_total{operation="GET",service="iam"} 10
upjet_resource_external_api_calls_total{operation="POST",service="compute"} 2
upjet_resource_external_api_calls_total{operation="POST",service="iam"} 1
```

[contribution process]: https://git.io/fj2m9
