### PR TITLE
Replace --init flag with init subcommand

### DIFF
--- a/cmd/provider/accesscontextmanager/zz_main.go
+++ b/cmd/provider/accesscontextmanager/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "accesscontextmanager"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/activedirectory/zz_main.go
+++ b/cmd/provider/activedirectory/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "activedirectory"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/alloydb/zz_main.go
+++ b/cmd/provider/alloydb/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "alloydb"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/apigee/zz_main.go
+++ b/cmd/provider/apigee/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "apigee"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/appengine/zz_main.go
+++ b/cmd/provider/appengine/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "appengine"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/artifact/zz_main.go
+++ b/cmd/provider/artifact/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "artifact"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/beyondcorp/zz_main.go
+++ b/cmd/provider/beyondcorp/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "beyondcorp"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/bigquery/zz_main.go
+++ b/cmd/provider/bigquery/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "bigquery"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/bigtable/zz_main.go
+++ b/cmd/provider/bigtable/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "bigtable"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/binaryauthorization/zz_main.go
+++ b/cmd/provider/binaryauthorization/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "binaryauthorization"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/certificatemanager/zz_main.go
+++ b/cmd/provider/certificatemanager/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "certificatemanager"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloud/zz_main.go
+++ b/cmd/provider/cloud/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloud"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudbuild/zz_main.go
+++ b/cmd/provider/cloudbuild/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudbuild"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudfunctions/zz_main.go
+++ b/cmd/provider/cloudfunctions/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudfunctions"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudfunctions2/zz_main.go
+++ b/cmd/provider/cloudfunctions2/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudfunctions2"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudidentity/zz_main.go
+++ b/cmd/provider/cloudidentity/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudidentity"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudplatform/zz_main.go
+++ b/cmd/provider/cloudplatform/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudplatform"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudquotas/zz_main.go
+++ b/cmd/provider/cloudquotas/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudquotas"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudrun/zz_main.go
+++ b/cmd/provider/cloudrun/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudrun"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudscheduler/zz_main.go
+++ b/cmd/provider/cloudscheduler/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudscheduler"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/cloudtasks/zz_main.go
+++ b/cmd/provider/cloudtasks/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "cloudtasks"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/composer/zz_main.go
+++ b/cmd/provider/composer/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "composer"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/compute/zz_main.go
+++ b/cmd/provider/compute/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "compute"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -95,7 +95,9 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 		}).String()
 	)
 
+	_ = app.Command("core", "Run the provider controllers.").Default()
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 

--- a/cmd/provider/container/zz_main.go
+++ b/cmd/provider/container/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "container"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/containeranalysis/zz_main.go
+++ b/cmd/provider/containeranalysis/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "containeranalysis"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/containerattached/zz_main.go
+++ b/cmd/provider/containerattached/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "containerattached"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/containeraws/zz_main.go
+++ b/cmd/provider/containeraws/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "containeraws"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/containerazure/zz_main.go
+++ b/cmd/provider/containerazure/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "containerazure"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/datacatalog/zz_main.go
+++ b/cmd/provider/datacatalog/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "datacatalog"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/dataflow/zz_main.go
+++ b/cmd/provider/dataflow/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "dataflow"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/datafusion/zz_main.go
+++ b/cmd/provider/datafusion/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "datafusion"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/datalossprevention/zz_main.go
+++ b/cmd/provider/datalossprevention/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "datalossprevention"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/dataplex/zz_main.go
+++ b/cmd/provider/dataplex/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "dataplex"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/dataproc/zz_main.go
+++ b/cmd/provider/dataproc/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "dataproc"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/datastream/zz_main.go
+++ b/cmd/provider/datastream/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "datastream"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/developerconnect/zz_main.go
+++ b/cmd/provider/developerconnect/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "developerconnect"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/dialogflowcx/zz_main.go
+++ b/cmd/provider/dialogflowcx/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "dialogflowcx"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/dns/zz_main.go
+++ b/cmd/provider/dns/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "dns"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/documentai/zz_main.go
+++ b/cmd/provider/documentai/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "documentai"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/essentialcontacts/zz_main.go
+++ b/cmd/provider/essentialcontacts/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "essentialcontacts"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/eventarc/zz_main.go
+++ b/cmd/provider/eventarc/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "eventarc"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/filestore/zz_main.go
+++ b/cmd/provider/filestore/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "filestore"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/firebaserules/zz_main.go
+++ b/cmd/provider/firebaserules/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "firebaserules"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/gemini/zz_main.go
+++ b/cmd/provider/gemini/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "gemini"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/gke/zz_main.go
+++ b/cmd/provider/gke/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "gke"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/gkehub/zz_main.go
+++ b/cmd/provider/gkehub/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "gkehub"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/healthcare/zz_main.go
+++ b/cmd/provider/healthcare/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "healthcare"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/iam/zz_main.go
+++ b/cmd/provider/iam/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "iam"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/iap/zz_main.go
+++ b/cmd/provider/iap/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "iap"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/identityplatform/zz_main.go
+++ b/cmd/provider/identityplatform/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "identityplatform"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/kms/zz_main.go
+++ b/cmd/provider/kms/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "kms"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/logging/zz_main.go
+++ b/cmd/provider/logging/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "logging"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/memcache/zz_main.go
+++ b/cmd/provider/memcache/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "memcache"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/memorystore/zz_main.go
+++ b/cmd/provider/memorystore/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "memorystore"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/mlengine/zz_main.go
+++ b/cmd/provider/mlengine/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "mlengine"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/modelarmor/zz_main.go
+++ b/cmd/provider/modelarmor/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "modelarmor"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/monitoring/zz_main.go
+++ b/cmd/provider/monitoring/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "monitoring"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -190,7 +191,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, ""), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/networkconnectivity/zz_main.go
+++ b/cmd/provider/networkconnectivity/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "networkconnectivity"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/networkmanagement/zz_main.go
+++ b/cmd/provider/networkmanagement/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "networkmanagement"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/networksecurity/zz_main.go
+++ b/cmd/provider/networksecurity/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "networksecurity"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/networkservices/zz_main.go
+++ b/cmd/provider/networkservices/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "networkservices"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/notebooks/zz_main.go
+++ b/cmd/provider/notebooks/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "notebooks"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/orgpolicy/zz_main.go
+++ b/cmd/provider/orgpolicy/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "orgpolicy"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/osconfig/zz_main.go
+++ b/cmd/provider/osconfig/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "osconfig"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/oslogin/zz_main.go
+++ b/cmd/provider/oslogin/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "oslogin"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/privateca/zz_main.go
+++ b/cmd/provider/privateca/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "privateca"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/pubsub/zz_main.go
+++ b/cmd/provider/pubsub/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "pubsub"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/redis/zz_main.go
+++ b/cmd/provider/redis/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "redis"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/secretmanager/zz_main.go
+++ b/cmd/provider/secretmanager/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "secretmanager"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/servicenetworking/zz_main.go
+++ b/cmd/provider/servicenetworking/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "servicenetworking"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/sourcerepo/zz_main.go
+++ b/cmd/provider/sourcerepo/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "sourcerepo"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/spanner/zz_main.go
+++ b/cmd/provider/spanner/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "spanner"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/sql/zz_main.go
+++ b/cmd/provider/sql/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "sql"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/storage/zz_main.go
+++ b/cmd/provider/storage/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "storage"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/storagetransfer/zz_main.go
+++ b/cmd/provider/storagetransfer/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "storagetransfer"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/tags/zz_main.go
+++ b/cmd/provider/tags/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "tags"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/vertexai/zz_main.go
+++ b/cmd/provider/vertexai/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "vertexai"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/vpcaccess/zz_main.go
+++ b/cmd/provider/vpcaccess/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "vpcaccess"), "Cannot run storage version migrator")
 		return
 	}

--- a/cmd/provider/workflows/zz_main.go
+++ b/cmd/provider/workflows/zz_main.go
@@ -94,11 +94,12 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
-
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
 	)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -185,7 +186,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-	if *init {
+	if cmd == initCmd.FullCommand() {
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, "workflows"), "Cannot run storage version migrator")
 		return
 	}

--- a/config/templates/main.go.tmpl
+++ b/config/templates/main.go.tmpl
@@ -95,13 +95,11 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			return nil
 		}).String()
 	)
-{{ if ne .Group "config" }}
+
 	_ = app.Command("core", "Run the provider controllers.").Default()
-	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+{{ if ne .Group "config" }}	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
-{{ else }}
-	_ = app.Command("core", "Run the provider controllers.").Default()
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+{{ else }}	kingpin.MustParse(app.Parse(os.Args[1:]))
 {{ end }}
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))

--- a/config/templates/main.go.tmpl
+++ b/config/templates/main.go.tmpl
@@ -94,11 +94,15 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 			certsDirSet = true
 			return nil
 		}).String()
+	)
 {{ if ne .Group "config" }}
-		init = app.Flag("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.").Short('i').Bool()
-{{ end }}	)
-
+	_ = app.Command("core", "Run the provider controllers.").Default()
+	initCmd := app.Command("init", "Run provider initialization tasks (e.g. storage version migration) and exit. Intended for use as an init container.")
+	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+{{ else }}
+	_ = app.Command("core", "Run the provider controllers.").Default()
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+{{ end }}
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 
@@ -190,7 +194,7 @@ func main() { //nolint:gocyclo // easier to follow as a unit
 	namespacedProvider, err := config.GetNamespacedProvider(ctx, sdkProvider, fwProvider, false)
 	kingpin.FatalIfError(err, "Cannot initialize the namespaced provider configuration")
 
-{{ if ne .Group "config" }}	if *init {
+{{ if ne .Group "config" }}	if cmd == initCmd.FullCommand() {
 		{{ if eq .Group "monolith" -}}
 		kingpin.FatalIfError(providerinit.RunStorageVersionMigration(ctx, logr, mgr, ""), "Cannot run storage version migrator")
 		{{- else -}}

--- a/examples/deploymentruntimeconfig-sv-migration.yaml
+++ b/examples/deploymentruntimeconfig-sv-migration.yaml
@@ -13,7 +13,7 @@
 #
 # NOTE: Do NOT apply this DRC to the family/config provider package. That
 # package has no managed resources with version history and does not generate
-# the --init flag, so the init container would fail to start.
+# the init subcommand, so the init container would fail to start.
 #
 # The init container image must match the provider package image being deployed.
 # Update the image tag whenever you upgrade the provider.
@@ -61,7 +61,7 @@ spec:
               # Must match the provider package image being deployed.
               image: xpkg.upbound.io/upbound/provider-gcp-storage:v3.0.0
               args:
-                - --init
+                - init
                 - --debug
               securityContext:
                 runAsUser: 2000


### PR DESCRIPTION
### Description of your changes

Replaces the boolean `--init` flag with proper `core`/`init` subcommands, aligning with the core crossplane convention. `core` is registered as the default subcommand, so running the provider binary without any arguments continues to work — the existing package manager deployment model is unaffected. Running with `init` triggers the storage version migration path (`init` container use case).

The `deploymentruntimeconfig-sv-migration.yaml` example is updated to use `init` as a positional subcommand instead of `--init`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

[Uptest-examples/storage/cluster/v1beta2/bucket.yaml](https://github.com/crossplane-contrib/provider-upjet-gcp/actions/runs/30361270922)

[contribution process]: https://git.io/fj2m9
