### PR TITLE
fix(container): prevent panic on empty kubelet_config in node_config diff

### DIFF
--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -7,6 +7,7 @@ package container
 import (
 	"encoding/base64"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -79,6 +80,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				return diff, nil
 			}
 			delete(diff.Attributes, "autopilot_cluster_policy_config.#")
+			dropEmptyKubeletConfigDiff(diff)
 			return diff, nil
 		}
 	})
@@ -116,9 +118,46 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				// attribute.
 				delete(diff.Attributes, "initial_node_count")
 			}
+			dropEmptyKubeletConfigDiff(diff)
 			return diff, nil
 		}
 	})
+}
+
+// dropEmptyKubeletConfigDiff removes empty node_config.*.kubelet_config block
+// entries from the computed diff. The underlying Terraform google provider's
+// expandNodeConfig enters its kubelet branch whenever the "kubelet_config" key
+// is present in the diff (`if v, ok := nodeConfig["kubelet_config"]; ok`), then
+// dereferences the result of expandKubeletConfig. When the block is present but
+// empty, expandKubeletConfig returns nil and the subsequent raw-config sub-fix
+// dereferences it, causing a nil-pointer panic. This is reachable through
+// upjet-driven reconciliation where a node_config is present without a
+// kubelet_config. Removing the empty ".#" entry makes the "ok" check false, so
+// the provider skips the branch entirely. This changes nothing when a real
+// kubelet_config is set (its ".#" is non-zero and is left untouched).
+func dropEmptyKubeletConfigDiff(diff *terraform.InstanceDiff) {
+	if diff == nil || diff.Attributes == nil {
+		return
+	}
+	for key, ad := range diff.Attributes {
+		if isEmptyNodeConfigKubeletCount(key, ad) {
+			delete(diff.Attributes, key)
+		}
+	}
+}
+
+// isEmptyNodeConfigKubeletCount reports whether key/ad is an empty
+// node_config.*.kubelet_config.# count entry (count 0/unset on both sides).
+func isEmptyNodeConfigKubeletCount(key string, ad *terraform.ResourceAttrDiff) bool {
+	if ad == nil {
+		return false
+	}
+	if !strings.HasSuffix(key, "kubelet_config.#") || !strings.Contains(key, "node_config.") {
+		return false
+	}
+	oldEmpty := ad.Old == "" || ad.Old == "0"
+	newEmpty := ad.New == "" || ad.New == "0"
+	return oldEmpty && newEmpty
 }
 
 // clusterConnectionDetails builds the kubeconfig published in the connection

--- a/config/cluster/container/config_test.go
+++ b/config/cluster/container/config_test.go
@@ -9,8 +9,58 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+func TestDropEmptyKubeletConfigDiff(t *testing.T) {
+	cases := map[string]struct {
+		attrs   map[string]*terraform.ResourceAttrDiff
+		dropped []string // keys expected to be removed
+		kept    []string // keys expected to remain
+	}{
+		"DropsEmptyNodePoolNested": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"node_pool.0.node_config.0.kubelet_config.#": {Old: "", New: "0"},
+			},
+			dropped: []string{"node_pool.0.node_config.0.kubelet_config.#"},
+		},
+		"DropsEmptyTopLevel": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"node_config.0.kubelet_config.#": {Old: "0", New: "0"},
+			},
+			dropped: []string{"node_config.0.kubelet_config.#"},
+		},
+		"KeepsNonEmptyKubeletConfig": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"node_config.0.kubelet_config.#": {Old: "0", New: "1"},
+			},
+			kept: []string{"node_config.0.kubelet_config.#"},
+		},
+		"IgnoresUnrelatedKubeletConfigOutsideNodeConfig": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"kubelet_config.#": {Old: "", New: "0"},
+			},
+			kept: []string{"kubelet_config.#"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			diff := &terraform.InstanceDiff{Attributes: tc.attrs}
+			dropEmptyKubeletConfigDiff(diff)
+			for _, k := range tc.dropped {
+				if _, ok := diff.Attributes[k]; ok {
+					t.Errorf("expected key %q to be dropped, but it remained", k)
+				}
+			}
+			for _, k := range tc.kept {
+				if _, ok := diff.Attributes[k]; !ok {
+					t.Errorf("expected key %q to be kept, but it was dropped", k)
+				}
+			}
+		})
+	}
+}
 
 func TestClusterConnectionDetails(t *testing.T) {
 	caPEM := []byte("-----BEGIN CERTIFICATE-----\nprivate-cluster-ca\n-----END CERTIFICATE-----")

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -7,6 +7,7 @@ package container
 import (
 	"encoding/base64"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -79,6 +80,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				return diff, nil
 			}
 			delete(diff.Attributes, "autopilot_cluster_policy_config.#")
+			dropEmptyKubeletConfigDiff(diff)
 			return diff, nil
 		}
 	})
@@ -116,9 +118,46 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				// attribute.
 				delete(diff.Attributes, "initial_node_count")
 			}
+			dropEmptyKubeletConfigDiff(diff)
 			return diff, nil
 		}
 	})
+}
+
+// dropEmptyKubeletConfigDiff removes empty node_config.*.kubelet_config block
+// entries from the computed diff. The underlying Terraform google provider's
+// expandNodeConfig enters its kubelet branch whenever the "kubelet_config" key
+// is present in the diff (`if v, ok := nodeConfig["kubelet_config"]; ok`), then
+// dereferences the result of expandKubeletConfig. When the block is present but
+// empty, expandKubeletConfig returns nil and the subsequent raw-config sub-fix
+// dereferences it, causing a nil-pointer panic. This is reachable through
+// upjet-driven reconciliation where a node_config is present without a
+// kubelet_config. Removing the empty ".#" entry makes the "ok" check false, so
+// the provider skips the branch entirely. This changes nothing when a real
+// kubelet_config is set (its ".#" is non-zero and is left untouched).
+func dropEmptyKubeletConfigDiff(diff *terraform.InstanceDiff) {
+	if diff == nil || diff.Attributes == nil {
+		return
+	}
+	for key, ad := range diff.Attributes {
+		if isEmptyNodeConfigKubeletCount(key, ad) {
+			delete(diff.Attributes, key)
+		}
+	}
+}
+
+// isEmptyNodeConfigKubeletCount reports whether key/ad is an empty
+// node_config.*.kubelet_config.# count entry (count 0/unset on both sides).
+func isEmptyNodeConfigKubeletCount(key string, ad *terraform.ResourceAttrDiff) bool {
+	if ad == nil {
+		return false
+	}
+	if !strings.HasSuffix(key, "kubelet_config.#") || !strings.Contains(key, "node_config.") {
+		return false
+	}
+	oldEmpty := ad.Old == "" || ad.Old == "0"
+	newEmpty := ad.New == "" || ad.New == "0"
+	return oldEmpty && newEmpty
 }
 
 // clusterConnectionDetails builds the kubeconfig published in the connection

--- a/config/namespaced/container/config_test.go
+++ b/config/namespaced/container/config_test.go
@@ -9,8 +9,58 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+func TestDropEmptyKubeletConfigDiff(t *testing.T) {
+	cases := map[string]struct {
+		attrs   map[string]*terraform.ResourceAttrDiff
+		dropped []string // keys expected to be removed
+		kept    []string // keys expected to remain
+	}{
+		"DropsEmptyNodePoolNested": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"node_pool.0.node_config.0.kubelet_config.#": {Old: "", New: "0"},
+			},
+			dropped: []string{"node_pool.0.node_config.0.kubelet_config.#"},
+		},
+		"DropsEmptyTopLevel": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"node_config.0.kubelet_config.#": {Old: "0", New: "0"},
+			},
+			dropped: []string{"node_config.0.kubelet_config.#"},
+		},
+		"KeepsNonEmptyKubeletConfig": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"node_config.0.kubelet_config.#": {Old: "0", New: "1"},
+			},
+			kept: []string{"node_config.0.kubelet_config.#"},
+		},
+		"IgnoresUnrelatedKubeletConfigOutsideNodeConfig": {
+			attrs: map[string]*terraform.ResourceAttrDiff{
+				"kubelet_config.#": {Old: "", New: "0"},
+			},
+			kept: []string{"kubelet_config.#"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			diff := &terraform.InstanceDiff{Attributes: tc.attrs}
+			dropEmptyKubeletConfigDiff(diff)
+			for _, k := range tc.dropped {
+				if _, ok := diff.Attributes[k]; ok {
+					t.Errorf("expected key %q to be dropped, but it remained", k)
+				}
+			}
+			for _, k := range tc.kept {
+				if _, ok := diff.Attributes[k]; !ok {
+					t.Errorf("expected key %q to be kept, but it was dropped", k)
+				}
+			}
+		})
+	}
+}
 
 func TestClusterConnectionDetails(t *testing.T) {
 	caPEM := []byte("-----BEGIN CERTIFICATE-----\nprivate-cluster-ca\n-----END CERTIFICATE-----")


### PR DESCRIPTION
## Description

`expandNodeConfig` in the underlying Terraform google provider enters its kubelet branch whenever the `kubelet_config` key is present in the diff:

## Real-world panic (production, GKE cluster create ManagedResource)

```
create failed: async create failed: recovered from panic: value is null

github.com/hashicorp/go-cty/cty.Value.LengthInt(...)
    github.com/hashicorp/go-cty@v1.5.0/cty/value_ops.go:997
github.com/hashicorp/terraform-provider-google/google/services/container.expandNodeConfig(...)
    .../services/container/node_config.go:1841
github.com/hashicorp/terraform-provider-google/google/services/container.resourceContainerClusterCreate(...)
    .../services/container/resource_container_cluster.go:2985
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(...)
    .../helper/schema/resource.go:837
github.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginSDKExternal).Create(...)
    github.com/crossplane/upjet/v2/pkg/controller/external_tfpluginsdk.go:654
```

The panic is a `cty.Value.LengthInt()` call on a null value inside `expandNodeConfig`'s raw-config sub-fixes. When the SDK is driven programmatically, `GetRawConfig()` (and nested attributes such as `node_pool` / `node_config` / `kubelet_config`) can be null, so `LengthInt()` / `GetAttr()` / `Index()` panic


```go
if v, ok := nodeConfig["kubelet_config"]; ok {
    nc.KubeletConfig = expandKubeletConfig(v) // returns nil when the block is empty
    ...
    // later raw-config sub-fix dereferences nc.KubeletConfig -> nil pointer panic
}
```

When a `node_config` is present but its `kubelet_config` block is **empty**, `expandKubeletConfig` returns `nil`, and a subsequent raw-config sub-fix dereferences it, causing a nil-pointer panic.

Plain Terraform HCL always populates `kubelet_config`, so it never hits this path. But **upjet-driven reconciliation** can present a Cluster/NodePool `node_config` without a `kubelet_config` block, which reliably triggers the panic on create/update.

## Fix

Add a `TerraformCustomDiff` post-processing step, `dropEmptyKubeletConfigDiff`, wired into the existing Cluster and NodePool CustomDiff hooks in **both** the cluster-scoped and namespaced container configs.

It removes only **empty** `node_config.*.kubelet_config.#` diff entries (count `0`/unset on both `Old` and `New`). This makes the provider's `if _, ok := nodeConfig["kubelet_config"]; ok` check false, so the branch is skipped entirely.

## Behaviour

- **Behaviour-neutral.** A real `kubelet_config` (non-zero `.#`) is left untouched, so any configuration that actually sets kubelet fields is unaffected.
- Only removes an entry that would otherwise cause a guaranteed panic.

## Tests

Unit tests added for both scopes covering:
- empty `kubelet_config` block → entry dropped (no panic)
- populated `kubelet_config` block → entry preserved (unchanged behaviour)

## I have:

- [x] Run `make reviewable` to ensure this PR is ready for review (build + vet + the container config tests pass).

## Related

Root-cause nil-safety fix pursued upstream in the Terraform google provider: GoogleCloudPlatform/magic-modules#18800. This PR provides the provider-side defence-in-depth so the fix does not depend on the upstream timeline.
